### PR TITLE
Fail on requests with unknown headers matching X-Thentos-*.

### DIFF
--- a/exec/BuildDocs.hs
+++ b/exec/BuildDocs.hs
@@ -28,6 +28,7 @@ import Text.Pandoc (writeMarkdown, writeHtml, writeDocx, def)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Servant.Docs as Docs
 
+import Thentos.Backend.Core
 import Thentos.Types
 
 import qualified Thentos.Backend.Api.Adhocracy3 as Adhocracy3
@@ -82,6 +83,9 @@ xsystem cmd = do
 
 
 instance HasDocs sublayout => HasDocs (Simple.ThentosAuth sublayout) where
+    docsFor Proxy = docsFor (Proxy :: Proxy sublayout)
+
+instance HasDocs sublayout => HasDocs (ThentosAssertHeaders sublayout) where
     docsFor Proxy = docsFor (Proxy :: Proxy sublayout)
 
 

--- a/src/Thentos/Backend/Api/Proxy.hs
+++ b/src/Thentos/Backend/Api/Proxy.hs
@@ -94,7 +94,7 @@ getRqMod req = do
 
     hdrs <- do
         (_, session) <- maybe (lift $ left NoSuchSession) (bumpSession . SessionToken) $
-            lookupRequestHeader req "X-Thentos-Session"
+            lookupRequestHeader req ThentosHeaderSession
         (_, user) <- case session ^. sessionAgent of
             UserA uid  -> queryAction $ LookupUser uid
             ServiceA _ -> lift $ left NoSuchUser
@@ -105,7 +105,7 @@ getRqMod req = do
                 []
         return newHdrs
 
-    sid <- case lookupRequestHeader req "X-Thentos-Service" of
+    sid <- case lookupRequestHeader req ThentosHeaderService of
             Just s  -> return $ ServiceId s
             Nothing -> lift $ left MissingServiceHeader
 

--- a/src/Thentos/Backend/Api/Simple.hs
+++ b/src/Thentos/Backend/Api/Simple.hs
@@ -32,7 +32,8 @@ import Servant.Server (serve)
 
 import Thentos.Api
 import Thentos.Backend.Api.Proxy
-import Thentos.Backend.Core (RestActionState, PushActionC, PushActionSubRoute, pushAction, lookupRequestHeader)
+import Thentos.Backend.Core (RestActionState, PushActionC, PushActionSubRoute, pushAction)
+import Thentos.Backend.Core (ThentosAssertHeaders, ThentosHeaderName(..), lookupRequestHeader)
 import Thentos.DB
 import Thentos.Types
 import Thentos.Util
@@ -48,7 +49,7 @@ serveApi = serve (Proxy :: Proxy App) . app
 
 -- * the application
 
-type App = ThentosAuth ThentosBasic
+type App = ThentosAssertHeaders (ThentosAuth ThentosBasic)
 
 app :: ActionStateGlobal (MVar SystemRNG) -> Server App
 app asg = ThentosAuth asg thentosBasic
@@ -87,7 +88,7 @@ instance ( PushActionC (Server sublayout)
       where
         routingState :: RestActionState
         routingState = ( asg
-                       , makeThentosClearance $ lookupRequestHeader request "X-Thentos-Session"
+                       , makeThentosClearance $ lookupRequestHeader request ThentosHeaderSession
                        )
 
 

--- a/src/Thentos/Backend/Core.hs
+++ b/src/Thentos/Backend/Core.hs
@@ -107,14 +107,8 @@ data ThentosHeaderName =
 
 renderThentosHeaderName :: ThentosHeaderName -> CI SBS
 renderThentosHeaderName x = case splitAt (SBS.length "ThentosHeader") (show x) of
-    (_, s) -> mk . SBS.pack $ "X-Thentos" ++ dashify s
-
-    -- (oddness: it would be strictly better to use the pattern
-    -- @("ThentosHeader", s)@ here: if "ThentosHeader" does not match,
-    -- we *want* this to crash, but we are pretty confident that it
-    -- won't.  but if we do not use an @_@ here, we get an
-    -- unmatched-pattern warning.)
-
+    ("ThentosHeader", s) -> mk . SBS.pack $ "X-Thentos" ++ dashify s
+    bad -> error $ "renderThentosHeaderName: bad prefix (left side) in " ++ show bad
   where
     dashify ""    = ""
     dashify (h:t) = if isUpper h


### PR DESCRIPTION
(See comment in the test case on why this is a 500 error and not something more sane.)