### PR TITLE
Handle attempts to create new user with existing email address

### DIFF
--- a/src/Thentos/Backend/Api/Adhocracy3.hs
+++ b/src/Thentos/Backend/Api/Adhocracy3.hs
@@ -299,7 +299,7 @@ addUser (A3UserWithPass user) = logActionError $ do
     logger DEBUG . ("route addUser:" <>) . cs . Aeson.encodePretty $ A3UserWithPass user
     ((_, _, config :: ThentosConfig), _) <- ask
     (uid :: UserId, tok :: ConfirmationToken) <- addUnconfirmedUser user
-    let activationUrl = "http://localhost:" <> cs (show feport) <> "/signup_confirm/" <> enctok
+    let activationUrl = "http://localhost:" <> cs (show feport) <> "/signup_confirm/" <> cs enctok
         feport :: Int = frontendPort . fromJustNote "addUser: frontend not configured!" . frontendConfig $ config
         enctok :: SBS = urlEncode . cs . fromConfimationToken $ tok
     liftIO $ sendUserConfirmationMail (smtpConfig config) user activationUrl

--- a/src/Thentos/DB/Trans.hs
+++ b/src/Thentos/DB/Trans.hs
@@ -259,6 +259,11 @@ writeUser uid user = do
     modify $ dbUsers %~ Map.insert uid user
     returnDb label ()
 
+emailAddressExists :: UserEmail -> DB -> Bool
+emailAddressExists address db =
+    let userEmails = map (^. userEmail) . Map.elems $ db ^. dbUsers in
+    address `elem` userEmails
+
 
 -- ** services
 
@@ -611,12 +616,6 @@ trans_snapShot :: ThentosQuery DB
 trans_snapShot = do
     let label = RoleAdmin =%% False
     ask >>= returnDb label
-
-emailAddressExists :: UserEmail -> DB -> Bool
-emailAddressExists address db =
-    let userEmails = map (^. userEmail) . Map.elems $ db ^. dbUsers in
-    address `elem` userEmails
-
 
 -- * event types
 

--- a/src/Thentos/Frontend.hs
+++ b/src/Thentos/Frontend.hs
@@ -16,7 +16,7 @@ import Data.ByteString (ByteString)
 import Data.Functor.Infix ((<$$>))
 import Data.Monoid ((<>))
 import Data.String.Conversions (cs)
-import Data.Text.Encoding (decodeUtf8', encodeUtf8)
+import Data.Text.Encoding (decodeUtf8, decodeUtf8', encodeUtf8)
 import Snap.Blaze (blaze)
 import Snap.Core (getResponse, finishWith, method, Method(GET, POST), ifTop, urlEncode)
 import Snap.Core (rqURI, getParam, getsRequest, redirect', parseUrlEncoded, printUrlEncoded, modifyResponse, setResponseStatus)
@@ -29,6 +29,7 @@ import System.Log (Priority(DEBUG, INFO, WARNING))
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.Map as M
+import qualified Data.Text.Lazy as L
 
 import System.Log.Missing (logger)
 import Thentos.Api
@@ -91,7 +92,9 @@ userAddHandler = do
                     config :: ThentosConfig <- gets (^. cfg)
                     let Just (feConfig :: FrontendConfig) = frontendConfig config
                         url = "http://localhost:" <> (cs . show . frontendPort $ feConfig)
-                                <> "/signup_confirm?token=" <> urlEncode (encodeUtf8 token)
+                                <> "/signup_confirm?token="
+                                <> (L.fromStrict . decodeUtf8 . urlEncode $ encodeUtf8 token)
+                                -- encodeUtf8 . urlEncode is fine
                     liftIO $ sendUserConfirmationMail (smtpConfig config) user url
                     blaze emailSentPage
                 Left UserEmailAlreadyExists -> do

--- a/src/Thentos/Frontend/Pages.hs
+++ b/src/Thentos/Frontend/Pages.hs
@@ -10,6 +10,7 @@ module Thentos.Frontend.Pages
     , serviceAddedPage
     , loginPage
     , loginForm
+    , emailSentPage
     , errorPage
 ) where
 
@@ -119,6 +120,9 @@ loginForm :: Monad m => Form Html m (UserName, UserPass)
 loginForm = (,)
     <$> (UserName  <$> "name"     .: check "name must not be empty"     nonEmpty   (text Nothing))
     <*> (UserPass <$> "password" .: check "password must not be empty" nonEmpty   (text Nothing))
+
+emailSentPage :: Html
+emailSentPage = H.string $ "Please check your email"
 
 errorPage :: String -> Html
 errorPage errorString = H.string $ "Encountered error: " ++ show errorString

--- a/src/Thentos/Smtp.hs
+++ b/src/Thentos/Smtp.hs
@@ -1,31 +1,54 @@
 {-# LANGUAGE OverloadedStrings                        #-}
 
-module Thentos.Smtp (sendUserConfirmationMail) where
+module Thentos.Smtp
+    ( sendUserConfirmationMail
+    , sendUserExistsMail
+) where
 
 import Data.ByteString (ByteString)
 import Data.Monoid ((<>))
 import Data.String.Conversions (cs)
+import Data.Text (Text)
 import Network.Mail.Mime (Address(Address), renderSendMailCustom, Mail(..), emptyMail, Part(..), Encoding(None))
 import System.Log (Priority(DEBUG))
 
 import qualified Data.ByteString.Lazy as L
 
 import System.Log.Missing
-import Thentos.Config
+import Thentos.Config (SmtpConfig(SmtpConfig))
 import Thentos.Types
 
 sendUserConfirmationMail :: SmtpConfig -> UserFormData -> ByteString -> IO ()
-sendUserConfirmationMail (SmtpConfig sentFromAddress sendmailPath sendmailArgs) user callbackUrl = do
+sendUserConfirmationMail smtpConfig user callbackUrl = do
     logger DEBUG $ "sending user-create-confirm mail: " ++ show user ++ " " ++ cs callbackUrl
+    sendMail smtpConfig subject message (udEmail user)
+  where
+    message = "Please go to " <> L.fromStrict callbackUrl
+    subject = "Thentos account creation confirmation"
+
+sendUserExistsMail :: SmtpConfig -> UserEmail -> IO ()
+sendUserExistsMail smtpConfig address = do
+    logger DEBUG $ "sending user-already-exists mail: " ++ show address
+    sendMail smtpConfig subject message address
+  where
+    message = "Someone tried to sign up to Thentos with your email address"
+                <> "\nThis is a reminder that you already have a Thentos"
+                <> " account. If you haven't tried to sign up to Thentos, you"
+                <> " can just ignore this email."
+    subject = "Attempted Thentos Signup"
+
+-- FIXME: when we have more interesting emails, the message body should be Text
+sendMail :: SmtpConfig -> Text -> L.ByteString -> UserEmail -> IO ()
+sendMail config subject message address = do
     renderSendMailCustom sendmailPath sendmailArgs mail
   where
+    SmtpConfig sentFromAddress sendmailPath sendmailArgs = config
     mail = (emptyMail sentFromAddress)
             { mailTo = [receiverAddress]
             , mailHeaders = headers
             , mailParts = [body]
             }
-    receiverAddress = Address Nothing (fromUserEmail $ udEmail user)
-    message = "Please go to " <> L.fromStrict callbackUrl
+    receiverAddress = Address Nothing (fromUserEmail $ address)
     body = [Part { partType = "text"
                  , partFilename = Nothing
                  , partHeaders = []
@@ -33,4 +56,4 @@ sendUserConfirmationMail (SmtpConfig sentFromAddress sendmailPath sendmailArgs) 
                  , partEncoding = None
                  }
            ]
-    headers = [("Subject", "Thentos account creation confirmation")]
+    headers = [("Subject", subject)]


### PR DESCRIPTION
When someone tries to sign up with an email address that we already have in the database, we now send a "By the way, you're already signed up for Thentos" email instead of creating an unconfirmed user with the same email address. However, the user still gets the same response from the frontend, to avoid leaking user data.