### PR TITLE
Split up roles into two types (maintains representation in config files)

### DIFF
--- a/src/Thentos/Config.hs
+++ b/src/Thentos/Config.hs
@@ -103,7 +103,7 @@ type DefaultUserConfig' =
             ("name"     :> ST)  -- FIXME: use more specific type?
   :*>       ("password" :> ST)  -- FIXME: use more specific type?
   :*>       ("email"    :> ST)  -- FIXME: use more specific type 'Network.Mail.Mime.Address'
-  :*> Maybe ("roles"    :> [Role])
+  :*> Maybe ("roles"    :> [RoleBasic])
 
 
 -- * leaf types
@@ -193,7 +193,7 @@ getUserData cfg = UserFormData
     (UserEmail (cfg >>. (Proxy :: Proxy '["email"])))
 
 getDefaultUser :: DefaultUserConfig -> (UserFormData, [Role])
-getDefaultUser cfg = (getUserData cfg, fromMaybe [] $ cfg >>. (Proxy :: Proxy '["roles"]))
+getDefaultUser cfg = (getUserData cfg, RoleBasic <$> fromMaybe [] (cfg >>. (Proxy :: Proxy '["roles"])))
 
 
 -- * logging

--- a/src/Thentos/Frontend.hs
+++ b/src/Thentos/Frontend.hs
@@ -26,7 +26,7 @@ import Thentos.Api
 import Thentos.Config
 import Thentos.Frontend.Types
 import Thentos.Frontend.Util (serveSnaplet)
-import Thentos.Types (Role(..))
+import Thentos.Types (Role(..), RoleBasic(..))
 
 import qualified Text.Blaze.Html5 as Blaze
 import qualified Thentos.Frontend.Handlers as H
@@ -78,7 +78,7 @@ routes = [ ("", ifTop $ H.index)
          , ("/dashboard/details", H.dashboardDetails)
 
          , ("test", blaze $ P.dashboardPagelet
-                 [RoleUser, RoleUserAdmin, RoleServiceAdmin, RoleAdmin]
+                 (RoleBasic <$> [RoleUser, RoleUserAdmin, RoleServiceAdmin, RoleAdmin])
                  P.DashboardTabDetails
                  (Blaze.text "body"))
          ]

--- a/src/Thentos/Frontend/Pages.hs
+++ b/src/Thentos/Frontend/Pages.hs
@@ -227,9 +227,9 @@ dashboardPagelet availableRoles ((==) -> isActive) body =
 
     needsRoles :: DashboardTab -> [Role]
     needsRoles DashboardTabDetails = []
-    needsRoles DashboardTabServices = [RoleUser]
-    needsRoles DashboardTabOwnServices = [RoleServiceAdmin]
-    needsRoles DashboardTabUsers = [RoleUserAdmin]
+    needsRoles DashboardTabServices = [RoleBasic RoleUser]
+    needsRoles DashboardTabOwnServices = [RoleBasic RoleServiceAdmin]
+    needsRoles DashboardTabUsers = [RoleBasic RoleUserAdmin]
     needsRoles DashboardTabLogout = []
 
     linkText :: DashboardTab -> Text

--- a/src/Thentos/Types.hs
+++ b/src/Thentos/Types.hs
@@ -278,7 +278,7 @@ data Agent = UserA !UserId | ServiceA !ServiceId
 instance Aeson.FromJSON Agent where parseJSON = Aeson.gparseJson
 instance Aeson.ToJSON Agent where toJSON = Aeson.gtoJson
 
-data Role =
+data RoleBasic =
     RoleAdmin
     -- ^ Can do anything.  (There may be no difference in behaviour
     -- from 'allowEverything' resp. 'thentosPublic', but if we ever
@@ -298,16 +298,21 @@ data Role =
 
   | RoleServiceAdmin
     -- ^ Can create (and manage her own) services
+  deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Generic)
 
-  | Roles [Role]
-    -- ^ (Super-roles)
+instance Aeson.FromJSON RoleBasic where parseJSON = Aeson.gparseJson
+instance Aeson.ToJSON RoleBasic where toJSON = Aeson.gtoJson
 
+data Role =
+    Roles [Role]
+  | RoleBasic RoleBasic
   deriving (Eq, Ord, Show, Read, Typeable, Generic)
 
 instance Aeson.FromJSON Role where parseJSON = Aeson.gparseJson
 instance Aeson.ToJSON Role where toJSON = Aeson.gtoJson
 
 instance ToCNF Agent where toCNF = toCNF . show
+instance ToCNF RoleBasic where toCNF = toCNF . show
 instance ToCNF Role where toCNF = toCNF . show
 
 -- | Wrapper for lio's 'Labeled' to avoid orphan instances.  (Also,
@@ -420,3 +425,4 @@ $(deriveSafeCopy 0 'base ''GroupNode)
 $(deriveSafeCopy 0 'base ''UserId)
 $(deriveSafeCopy 0 'base ''Agent)
 $(deriveSafeCopy 0 'base ''Role)
+$(deriveSafeCopy 0 'base ''RoleBasic)

--- a/src/Thentos/Types.hs
+++ b/src/Thentos/Types.hs
@@ -312,7 +312,7 @@ instance Aeson.FromJSON Role where parseJSON = Aeson.gparseJson
 instance Aeson.ToJSON Role where toJSON = Aeson.gtoJson
 
 instance ToCNF Agent where toCNF = toCNF . show
-instance ToCNF RoleBasic where toCNF = toCNF . show
+instance ToCNF RoleBasic where toCNF = toCNF . RoleBasic
 instance ToCNF Role where toCNF = toCNF . show
 
 -- | Wrapper for lio's 'Labeled' to avoid orphan instances.  (Also,

--- a/tests/Thentos/Backend/Api/SimpleSpec.hs
+++ b/tests/Thentos/Backend/Api/SimpleSpec.hs
@@ -54,6 +54,7 @@ spec = do
                     response1 <- srequest $ makeSRequest "GET" "/user" godCredentials ""
                     liftIO $ C.statusCode (simpleStatus response1) `shouldBe` 200
                     liftIO $ Aeson.decode' (simpleBody response1) `shouldBe` Just [UserId 0, UserId 1, UserId 2]
+
                 it "is not accessible for users without 'Admin' role" $
                         \ (_, testBackend, _, _) -> debugRunSession False testBackend $ do
                     response1 <- srequest $ makeSRequest "GET" "/user" [] ""

--- a/tests/ThentosSpec.hs
+++ b/tests/ThentosSpec.hs
@@ -126,12 +126,12 @@ spec = describe "DB" . before (setupDB testThentosConfig) . after teardownDB $ d
         describe "assign" $ do
             it "can be called by admins" $ \ (st, _, _) -> do
                 let targetAgent = UserA $ UserId 1
-                result <- update' st $ AssignRole targetAgent RoleAdmin (RoleAdmin *%% RoleAdmin)
+                result <- update' st $ AssignRole targetAgent (RoleBasic RoleAdmin) (RoleAdmin *%% RoleAdmin)
                 result `shouldSatisfy` isRight
 
             it "can NOT be called by any non-admin agents" $ \ (st, _, _) -> do
                 let targetAgent = UserA $ UserId 1
-                result <- update' st $ AssignRole targetAgent RoleAdmin (targetAgent *%% targetAgent)
+                result <- update' st $ AssignRole targetAgent (RoleBasic RoleAdmin) (targetAgent *%% targetAgent)
                 result `shouldSatisfy` isLeft
 
         describe "lookup" $ do


### PR DESCRIPTION
also fixes bug introduced unnoticed a bit earlier.