### PR TITLE
Clarify use of `before` and `after` in hspec

### DIFF
--- a/tests/MetaSpec.hs
+++ b/tests/MetaSpec.hs
@@ -1,0 +1,26 @@
+module MetaSpec where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef, modifyIORef)
+import Test.Hspec (Spec, describe, it, before_, shouldBe, runIO)
+
+-- `before` and `after` hooks are run before and after each spec item (see
+-- http://hspec.github.io/writing-specs.html ). Illustrative example:
+
+spec :: Spec
+spec = do
+    ref <- runIO (newIORef 123)
+    describe "all the tests" . before_ (beforeAction ref) $ do
+        spec_foo ref
+
+beforeAction :: IORef Int -> IO ()
+beforeAction ref = writeIORef ref 0
+
+spec_foo :: IORef Int -> Spec
+spec_foo ref = describe "do the test" $ do
+    it "first spec item modifies environment" $ do
+        cur <- readIORef ref
+        cur `shouldBe` 0
+        modifyIORef ref (+ 1)
+    it "environment gets cleaned up before second test item" $ do
+        cur <- readIORef ref
+        cur `shouldBe` 0

--- a/tests/Thentos/FrontendSpec.hs
+++ b/tests/Thentos/FrontendSpec.hs
@@ -80,7 +80,6 @@ spec_createUser = describe "create user" $ do
             WD.findElem (WD.ById "create_user_submit") >>= WD.click
             WD.getSource >>= \ s -> liftIO $ (cs s) `shouldSatisfy` (=~# "Please check your email")
 
-    it "click activation link." $ \ fts -> do
         let ActionState (st, _, _) = fts ^. ftsActionState
             feConfig = fts ^. ftsFrontendCfg
             wd = fts ^. ftsRunWD
@@ -97,11 +96,11 @@ spec_createUser = describe "create user" $ do
                   WD.getSource >>= \ s -> liftIO $ cs s `shouldSatisfy` (=~# "Registration complete")
               bad -> error $ "dbUnconfirmedUsers: " ++ show bad
 
-    it "check user in DB." $ \ fts -> do
-        let ActionState (st, _, _) = fts ^. ftsActionState
-        Right (db2 :: DB) <- query' st $ SnapShot
+        -- check that user is in db
+        let ActionState (st', _, _) = fts ^. ftsActionState
+        Right (db2 :: DB) <- query' st' $ SnapShot
         Map.size (db2 ^. dbUnconfirmedUsers) `shouldBe` 0
-        eUser <- query' st $ LookupUserByName (UserName myUsername)
+        eUser <- query' st' $ LookupUserByName (UserName myUsername)
         fromUserName  . (^. userName)  . snd <$> eUser `shouldBe` Right myUsername
         fromUserEmail . (^. userEmail) . snd <$> eUser `shouldBe` Right myEmail
 

--- a/tests/Thentos/FrontendSpec.hs
+++ b/tests/Thentos/FrontendSpec.hs
@@ -97,10 +97,9 @@ spec_createUser = describe "create user" $ do
               bad -> error $ "dbUnconfirmedUsers: " ++ show bad
 
         -- check that user is in db
-        let ActionState (st', _, _) = fts ^. ftsActionState
-        Right (db2 :: DB) <- query' st' $ SnapShot
+        Right (db2 :: DB) <- query' st $ SnapShot
         Map.size (db2 ^. dbUnconfirmedUsers) `shouldBe` 0
-        eUser <- query' st' $ LookupUserByName (UserName myUsername)
+        eUser <- query' st $ LookupUserByName (UserName myUsername)
         fromUserName  . (^. userName)  . snd <$> eUser `shouldBe` Right myUsername
         fromUserEmail . (^. userEmail) . snd <$> eUser `shouldBe` Right myEmail
 


### PR DESCRIPTION
Fixes #104 and fixes the original problem in the tests.