### PR TITLE
Add Cache-Control headers to all GET/HEAD responses from Servant.

### DIFF
--- a/src/Thentos/Backend/Api/Adhocracy3.hs
+++ b/src/Thentos/Backend/Api/Adhocracy3.hs
@@ -260,7 +260,7 @@ runBackend cfg asg = do
     runWarpWithCfg cfg $ serveApi asg
 
 serveApi :: AC.ActionState DB -> Application
-serveApi = serve (Proxy :: Proxy Api) . app
+serveApi = addResponseHeaders . serve (Proxy :: Proxy Api) . app
 
 
 -- * api

--- a/src/Thentos/Backend/Api/Simple.hs
+++ b/src/Thentos/Backend/Api/Simple.hs
@@ -44,7 +44,7 @@ runApi cfg asg = do
     runWarpWithCfg cfg $ serveApi asg
 
 serveApi :: ActionState DB -> Application
-serveApi = serve (Proxy :: Proxy Api) . api
+serveApi = addResponseHeaders . serve (Proxy :: Proxy Api) . api
 
 type Api = ThentosAssertHeaders :> ThentosAuth :> ThentosBasic
 


### PR DESCRIPTION
This solution also works for 4xx/5xx responses.

Fixes the Servant part of #112.