### PR TITLE
Proposed changes to layout section of styleguide.

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -70,9 +70,9 @@ synonyms match the module names that they are from.
 
 ## layout
 
-maximum line length is 140 chars.
+maximum line length is 100 chars.
 
 preceed haddock section headings with two empty lines.  succeed with
 one empty line.
 
-spacing in lambda: `\ x -> ...`; NOT: `\x -> ...`.
+spacing in lambda: `\x -> ...`; NOT: `\ x -> ...`.


### PR DESCRIPTION
Rationale:

* I consider anything between 100 and 120 a reaonable line length limit, so
  that's negotiable. But I think 140 is too long, and since I notice that
  Matthias' comment lines have at most 100 chars I went for the lower limit
  ;)

* I'm used to \x for lambdas and it seems more popular than \ x.
  Random examples from the web:
  https://wiki.haskell.org/Anonymous_function
  http://learnyouahaskell.com/higher-order-functions#lambdas

If the changes are adapted, I volunteer to adapt the existing code base,
if desired.