### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_install:
     - cd ../..
 install:
     - "./.travis/install.sh"
-    - cabal install --dependencies-only --enable-tests --ghc-options="-Werror"
+    - cabal install --dependencies-only --enable-tests
     - cabal install hlint
     - ./.cabal-sandbox/bin/hlint --version
     - find src tests exec -name '*.hs' | xargs ./.cabal-sandbox/bin/hlint
 script:
-    - cabal configure --enable-tests && cabal build && cabal test
+    - cabal configure --enable-tests --ghc-options="-Werror" && cabal build && cabal test


### PR DESCRIPTION
the `-Werror` flag was set for dependency building, not for thentos building.  stupid.