### PR TITLE
Configurable custom header names

### DIFF
--- a/src/Thentos/Backend/Api/Adhocracy3.hs
+++ b/src/Thentos/Backend/Api/Adhocracy3.hs
@@ -295,7 +295,8 @@ thentosApi actionState = enter (enterAction actionState Nothing) $
 api :: AC.ActionState DB -> Server Api
 api actionState =
        thentosApi actionState
-  :<|> serviceProxy actionState
+       -- TODO define distinct function
+  :<|> serviceProxy renderThentosHeaderName actionState
 
 
 -- * handler

--- a/src/Thentos/Backend/Api/Adhocracy3.hs
+++ b/src/Thentos/Backend/Api/Adhocracy3.hs
@@ -24,6 +24,7 @@ import Control.Monad.Error.Class (MonadError)
 import Control.Monad.Except (throwError)
 import Control.Monad (when, unless, mzero)
 import Data.Aeson (Value(Object), ToJSON, FromJSON, (.:), (.:?), (.=), object, withObject)
+import Data.CaseInsensitive (mk)
 import Data.Configifier ((>>.), Tagged(Tagged))
 import Data.Functor.Infix ((<$$>))
 import Data.List (stripPrefix)
@@ -298,8 +299,7 @@ thentosApi actionState = enter (enterAction actionState Nothing) $
 api :: AC.ActionState DB -> Server Api
 api actionState =
        thentosApi actionState
-       -- TODO define distinct function
-  :<|> serviceProxy renderThentosHeaderName actionState
+  :<|> serviceProxy renderA3HeaderName actionState
 
 
 -- * handler
@@ -345,6 +345,12 @@ login r = AC.logIfError'P $ do
 
 
 -- * aux
+
+-- | Render Thentos/A3-specific custom headers using the names expected by A3.
+renderA3HeaderName :: RenderHeaderFun
+renderA3HeaderName ThentosHeaderSession = mk "X-User-Token"
+renderA3HeaderName ThentosHeaderUser    = mk "X-User-Path"
+renderA3HeaderName h                    = renderThentosHeaderName h
 
 userIdToPath :: ThentosConfig -> UserId -> Path
 userIdToPath config (UserId i) = Path $ domain <> userpath

--- a/src/Thentos/Backend/Api/Adhocracy3Sso.hs
+++ b/src/Thentos/Backend/Api/Adhocracy3Sso.hs
@@ -131,8 +131,7 @@ api :: AC.ActionState DB -> Server Api
 api actionState =
        thentosA3Sso  actionState
   :<|> thentosApi404 actionState
-       -- TODO use different function
-  :<|> serviceProxy renderThentosHeaderName actionState
+  :<|> serviceProxy A3.renderA3HeaderName actionState
 
 
 -- * handler

--- a/src/Thentos/Backend/Api/Adhocracy3Sso.hs
+++ b/src/Thentos/Backend/Api/Adhocracy3Sso.hs
@@ -131,7 +131,8 @@ api :: AC.ActionState DB -> Server Api
 api actionState =
        thentosA3Sso  actionState
   :<|> thentosApi404 actionState
-  :<|> serviceProxy  actionState
+       -- TODO use different function
+  :<|> serviceProxy renderThentosHeaderName actionState
 
 
 -- * handler

--- a/src/Thentos/Backend/Api/Auth.hs
+++ b/src/Thentos/Backend/Api/Auth.hs
@@ -53,4 +53,5 @@ data ThentosAuth
 
 instance HasServer sub => HasServer (ThentosAuth :> sub) where
   type ServerT (ThentosAuth :> sub) m = Maybe ThentosSessionToken -> ServerT sub m
-  route Proxy sub request = route (Proxy :: Proxy sub) (sub $ lookupThentosHeaderSession request) request
+  route Proxy sub request = route (Proxy :: Proxy sub)
+      (sub $ lookupThentosHeaderSession renderThentosHeaderName request) request

--- a/src/Thentos/Backend/Api/Proxy.hs
+++ b/src/Thentos/Backend/Api/Proxy.hs
@@ -45,9 +45,9 @@ instance HasServer ServiceProxy where
   type ServerT ServiceProxy m = S.Application
   route Proxy = route (Proxy :: Proxy Raw)
 
-serviceProxy :: ActionState DB -> Server ServiceProxy
-serviceProxy state req cont = do
-    eRqMod <- runActionE state $ getRqMod req
+serviceProxy :: RenderHeaderFun -> ActionState DB -> Server ServiceProxy
+serviceProxy renderHeaderFun state req cont = do
+    eRqMod <- runActionE state $ getRqMod renderHeaderFun req
     case eRqMod of
         Right rqMod -> do
             C.withManager C.defaultManagerSettings $ \ manager ->
@@ -83,8 +83,11 @@ data RqMod = RqMod String T.RequestHeaders
 -- fill headers @X-Thentos-User@, @X-Thentos-Groups@.  If
 -- 'proxyConfig' is 'Nothing' or an invalid or inactive session token
 -- is provided, throw an error.
-getRqMod :: S.Request -> Action DB RqMod
-getRqMod req = do
+--
+-- The first parameter is a function that can be used to rename the Thentos-specific headers.
+-- To stick with the default names, use 'Thentos.Backend.Core.renderThentosHeaderName'.
+getRqMod :: RenderHeaderFun -> S.Request -> Action DB RqMod
+getRqMod renderHeaderFun req = do
     thentosConfig <- getConfig'P
 
     prxCfg :: Map.Map ServiceId HttpProxyConfig
@@ -92,14 +95,14 @@ getRqMod req = do
     (uid, user) :: (UserId, User)
         <- do
             tok <- maybe (throwError NoSuchThentosSession) return
-                         (lookupThentosHeaderSession req)
+                         (lookupThentosHeaderSession renderHeaderFun req)
             session <- lookupThentosSession tok
             case session ^. thSessAgent of
                 UserA uid  -> lookupUser uid
                 ServiceA sid -> throwError $ NeedUserA tok sid
 
     sid :: ServiceId
-        <- case lookupThentosHeaderService req of
+        <- case lookupThentosHeaderService renderHeaderFun req of
                Just s  -> return s
                Nothing -> throwError MissingServiceHeader
 
@@ -107,9 +110,9 @@ getRqMod req = do
         <- userGroups uid sid
 
     let hdrs =
-            ("X-Thentos-User", cs . fromUserName $ user ^. userName) :
-            ("X-Thentos-Groups", cs $ show groups) :
-            []
+            [ (renderHeaderFun ThentosHeaderUser, cs . fromUserName $ user ^. userName)
+            , (renderHeaderFun ThentosHeaderGroups, cs $ show groups)
+            ]
 
     target :: String
         <- case Map.lookup sid prxCfg of

--- a/src/Thentos/Backend/Core.hs
+++ b/src/Thentos/Backend/Core.hs
@@ -100,9 +100,13 @@ actionErrorToServantErr e = do
 
 -- * request headers
 
+-- FIXME This is the list of X-Thentos headers used in ALL backends. It would be better to allow
+-- each backend to define its own additional headers, but still to preserve type-safety.
 data ThentosHeaderName =
     ThentosHeaderSession
   | ThentosHeaderService
+  | ThentosHeaderUser
+  | ThentosHeaderGroups
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable)
 
 lookupThentosHeader :: Request -> ThentosHeaderName -> Maybe ST
@@ -117,14 +121,10 @@ lookupThentosHeaderService :: Request -> Maybe ServiceId
 lookupThentosHeaderService req = ServiceId <$> lookupThentosHeader req ThentosHeaderService
 
 renderThentosHeaderName :: ThentosHeaderName -> CI SBS
-renderThentosHeaderName x = case splitAt (SBS.length "ThentosHeader") (show x) of
-    ("ThentosHeader", s) -> mk . SBS.pack $ "X-Thentos" ++ dashify s
-    bad -> error $ "renderThentosHeaderName: prefix (left side) must be \"ThentosHeader\" in " ++ show bad
-  where
-    dashify ""    = ""
-    dashify (h:t) = if isUpper h
-        then '-' : h : dashify t
-        else       h : dashify t
+renderThentosHeaderName ThentosHeaderSession = mk "X-Thentos-Session"
+renderThentosHeaderName ThentosHeaderService = mk "X-Thentos-Service"
+renderThentosHeaderName ThentosHeaderUser    = mk "X-Thentos-User"
+renderThentosHeaderName ThentosHeaderGroups  = mk "X-Thentos-Groups"
 
 -- | Filter header list for all headers that start with "X-Thentos-", but have no parse in
 -- 'ThentosHeaderName'.

--- a/src/Thentos/Backend/Core.hs
+++ b/src/Thentos/Backend/Core.hs
@@ -152,7 +152,7 @@ badHeaders = filter g . filter f
 -- used as a basis for e.g. constructing another request to a proxy target.
 clearCustomHeaders :: RenderHeaderFun -> HttpTypes.RequestHeaders -> HttpTypes.RequestHeaders
 clearCustomHeaders renderHeaderFun = filter $ (`notElem` customHeaderNames) . fst
-  where customHeaderNames = map renderThentosHeaderName [minBound..]
+  where customHeaderNames = map renderHeaderFun [minBound..]
 
 -- | Make sure that all thentos headers are good ('badHeaders' yields empty list).
 data ThentosAssertHeaders = ThentosAssertHeaders

--- a/src/Thentos/Backend/Core.hs
+++ b/src/Thentos/Backend/Core.hs
@@ -148,10 +148,11 @@ badHeaders = filter g . filter f
     f (k, _) = foldCase "X-Thentos-" `SBS.isPrefixOf` foldedCase k
     g (k, _) = k `notElem` map renderThentosHeaderName [minBound..]
 
--- | Remove all headers that match @X-Thentos-.*@.  This is useful if the request is to be used as a
--- basis for e.g. constructing another request to a proxy target.
-clearThentosHeaders :: HttpTypes.RequestHeaders -> HttpTypes.RequestHeaders
-clearThentosHeaders = filter $ not . (foldedCase "X-Thentos-" `SBS.isPrefixOf`) . foldedCase . fst
+-- | Remove all headers matched by a 'RenderHeaderFun'.  This is useful if the request is to be
+-- used as a basis for e.g. constructing another request to a proxy target.
+clearCustomHeaders :: RenderHeaderFun -> HttpTypes.RequestHeaders -> HttpTypes.RequestHeaders
+clearCustomHeaders renderHeaderFun = filter $ (`notElem` customHeaderNames) . fst
+  where customHeaderNames = map renderThentosHeaderName [minBound..]
 
 -- | Make sure that all thentos headers are good ('badHeaders' yields empty list).
 data ThentosAssertHeaders = ThentosAssertHeaders


### PR DESCRIPTION
Allows redefining the names used for custom headers.

This is used in the A3 proxy to read and write the headers which A3 understands, e.g. "X-User-Path" instead of "X-Thentos-User".