### PR TITLE
Polymorphic error types for transactions.

### DIFF
--- a/src/Thentos/Action.hs
+++ b/src/Thentos/Action.hs
@@ -135,7 +135,7 @@ lookupUser uid = _lookupUser $ T.LookupUser uid
 
 _lookupUser :: ( QueryEvent event
                , EventState event ~ DB
-               , EventResult event ~ Either ThentosError (UserId, User)) =>
+               , EventResult event ~ Either (ThentosError DB) (UserId, User)) =>
                event -> Action DB (UserId, User)
 _lookupUser transaction = do
     val@(uid, _) <- query'P transaction
@@ -222,7 +222,7 @@ resetPassword token password = do
 -- the user map without any clearance.
 _lookupUserCheckPassword :: ( QueryEvent event
                             , EventState event ~ DB
-                            , EventResult event ~ Either ThentosError (UserId, User)) =>
+                            , EventResult event ~ Either (ThentosError DB) (UserId, User)) =>
     event -> UserPass -> Action DB (UserId, User)
 _lookupUserCheckPassword transaction password = a `catchError` h
   where

--- a/src/Thentos/Backend/Api/Adhocracy3.hs
+++ b/src/Thentos/Backend/Api/Adhocracy3.hs
@@ -361,7 +361,7 @@ userIdToPath config (UserId i) = Path $ domain <> userpath
                     Nothing -> error "userIdToPath: backend not configured!"
                     Just v -> Tagged v
 
-userIdFromPath :: MonadError ThentosError m => Path -> m UserId
+userIdFromPath :: MonadError (ThentosError DB) m => Path -> m UserId
 userIdFromPath (Path s) = do
     uri <- either (const . throwError . MalformedUserPath $ s) return $
         URI.parseURI URI.laxURIParserOptions $ cs s

--- a/src/Thentos/Backend/Core.hs
+++ b/src/Thentos/Backend/Core.hs
@@ -65,7 +65,7 @@ enterAction state mTok = Nat $ EitherT . run
 
 
 -- | Inspect an 'ActionError', log things, and construct a 'ServantErr'.
-actionErrorToServantErr :: ActionError -> IO ServantErr
+actionErrorToServantErr :: forall db . (AsDB db, db ~ DB) => ActionError db -> IO ServantErr
 actionErrorToServantErr e = do
     logger DEBUG $ ppShow e
     case e of
@@ -73,7 +73,7 @@ actionErrorToServantErr e = do
         (ActionErrorAnyLabel le) -> _permissions le
         (ActionErrorUnknown  _)  -> logger CRITICAL (ppShow e) >> pure err500
   where
-    _thentos :: ThentosError -> IO ServantErr
+    _thentos :: ThentosError db -> IO ServantErr
     _thentos NoSuchUser = pure $ err404 { errBody = "user not found" }
     _thentos NoSuchPendingUserConfirmation = pure $ err404 { errBody = "unconfirmed user not found" }
     _thentos (MalformedConfirmationToken path) = pure $ err400 { errBody = "malformed confirmation token: " <> cs (show path) }

--- a/src/Thentos/Frontend/Handlers.hs
+++ b/src/Thentos/Frontend/Handlers.hs
@@ -364,7 +364,7 @@ serviceLogin = do
         loggedIn :: FrontendSessionLoginData -> FH ()
         loggedIn fsl = do
             let tok = fsl ^. fslToken
-            eSessionToken :: Either ActionError ServiceSessionToken
+            eSessionToken :: Either (ActionError DB) ServiceSessionToken
                 <- snapRunActionE $ startServiceSession tok sid
 
             case eSessionToken of

--- a/src/Thentos/Frontend/Handlers/Combinators.hs
+++ b/src/Thentos/Frontend/Handlers/Combinators.hs
@@ -310,7 +310,7 @@ snapRunAction'P :: Action DB a -> FH a
 snapRunAction'P = (>>= snapHandleAllErrors) . snapRunActionE'P
 
 -- | Call 'snapHandleSomeErrors', and if error is still unhandled, call 'crash500'.
-snapHandleAllErrors :: Either ActionError a -> FH a
+snapHandleAllErrors :: Either (ActionError DB) a -> FH a
 snapHandleAllErrors eth = do
     result <- snapHandleSomeErrors eth
     case result of
@@ -325,7 +325,7 @@ getActionState = do
     return $ ActionState (st, rn, cf)
 
 -- | Run action with the clearance derived from thentos session token.
-snapRunActionE :: Action DB a -> FH (Either ActionError a)
+snapRunActionE :: Action DB a -> FH (Either (ActionError DB) a)
 snapRunActionE action = do
     st :: ActionState DB      <- getActionState
     fs :: FrontendSessionData <- getSessionData
@@ -336,7 +336,7 @@ snapRunActionE action = do
     snapHandleSomeErrors result
 
 -- | Call action with top clearance.
-snapRunActionE'P :: Action DB a -> FH (Either ActionError a)
+snapRunActionE'P :: Action DB a -> FH (Either (ActionError DB) a)
 snapRunActionE'P action = do
     st :: ActionState DB <- getActionState
     result <- liftIO $ runActionWithClearanceE dcTop st action
@@ -344,7 +344,7 @@ snapRunActionE'P action = do
 
 -- | This function handles particular error cases for the frontend and propagates others in 'Left'
 -- values.
-snapHandleSomeErrors :: Either ActionError a -> FH (Either ActionError a)
+snapHandleSomeErrors :: Either (ActionError DB) a -> FH (Either (ActionError DB) a)
 snapHandleSomeErrors (Right v) = return $ Right v
 snapHandleSomeErrors (Left e) = case e of
     ActionErrorAnyLabel labelError -> permissionDenied labelError

--- a/src/Thentos/Transaction/Core.hs
+++ b/src/Thentos/Transaction/Core.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE TupleSections        #-}
 
 module Thentos.Transaction.Core
-  ( ThentosUpdate, ThentosUpdate'
-  , ThentosQuery, ThentosQuery'
+  ( ThentosUpdate
+  , ThentosQuery
   , liftThentosQuery
   , runThentosUpdate
   , runThentosQuery
@@ -18,17 +18,15 @@ import Control.Monad.Reader (ReaderT(ReaderT), runReaderT, ask)
 import Control.Monad.State (StateT(StateT), runStateT, get, put)
 import Control.Monad.Trans.Either (EitherT(EitherT), runEitherT)
 import Data.Acid (Update, Query)
+import Data.EitherR (fmapL)
 
 import Thentos.Types
 
 
 -- * types
 
-type ThentosUpdate db a = ThentosUpdate' db ThentosError a
-type ThentosQuery  db a = ThentosQuery'  db ThentosError a
-
-type ThentosUpdate' db e a = EitherT e (StateT  db Identity) a
-type ThentosQuery'  db e a = EitherT e (ReaderT db Identity) a
+type ThentosUpdate db a = EitherT (ThentosError db) (StateT  db Identity) a
+type ThentosQuery  db a = EitherT (ThentosError db) (ReaderT db Identity) a
 
 -- FUTURE WORK: make primed types newtypes rather than type synonyms, and provide a generic monad
 -- instance.  (how does that work?)
@@ -37,7 +35,7 @@ type ThentosQuery'  db e a = EitherT e (ReaderT db Identity) a
 -- * plumbing
 
 -- | 'liftQuery' for 'ThentosUpdate' and 'ThentosUpdate''.
-liftThentosQuery :: ThentosQuery' db e a -> ThentosUpdate' db e a
+liftThentosQuery :: ThentosQuery db a -> ThentosUpdate db a
 liftThentosQuery thentosQuery = EitherT . StateT $ \ state ->
     (, state) <$> runEitherT thentosQuery `runReaderT` state
 
@@ -49,7 +47,7 @@ liftThentosQuery thentosQuery = EitherT . StateT $ \ state ->
 -- - http://petterbergman.se/aciderror.html.en
 -- - http://acid-state.seize.it/Error%20Scenarios
 -- - https://github.com/acid-state/acid-state/pull/38
-runThentosUpdate :: ThentosUpdate DB a -> Update DB (Either ThentosError a)
+runThentosUpdate :: ThentosUpdate DB a -> Update DB (Either (ThentosError DB) a)
 runThentosUpdate action = do
     state <- get
     case runIdentity $ runStateT (runEitherT action) state of
@@ -57,7 +55,7 @@ runThentosUpdate action = do
         (Right result, state') -> put state' >> (return $ Right result)
 
 -- | 'runThentosUpdate' for 'ThentosQuery' and 'ThentosQuery''
-runThentosQuery :: ThentosQuery DB a -> Query DB (Either ThentosError a)
+runThentosQuery :: ThentosQuery DB a -> Query DB (Either (ThentosError DB) a)
 runThentosQuery action = runIdentity . runReaderT (runEitherT action) <$> ask
 
 
@@ -68,13 +66,13 @@ runThentosQuery action = runIdentity . runReaderT (runEitherT action) <$> ask
 --  1. shouldn't there be a way to do both cases with one function @poly@?
 --  2. shouldn't there be a way to make acid-state events polymorphic in the state type?  (first try
 --     without the template haskell magic, then, if that works, it should also work magically.)
-polyUpdate :: forall e a db . AsDB db => ThentosUpdate' DB e a -> ThentosUpdate' db e a
+polyUpdate :: forall a db . AsDB db => ThentosUpdate DB a -> ThentosUpdate db a
 polyUpdate upd = EitherT . StateT $ Identity . (asDB %%~ bare)
   where
-    bare :: DB -> (Either e a, DB)
-    bare = runIdentity . runStateT (runEitherT upd)
+    bare :: DB -> (Either (ThentosError db) a, DB)
+    bare = runIdentity . runStateT (fmapL asDBThentosError <$> runEitherT upd)
 
 -- | Turn a query transaction on 'DB' into one on any 'AsDB' instance.  See also 'polyUpdate'.
-polyQuery :: AsDB db => ThentosQuery' DB e a -> ThentosQuery' db e a
+polyQuery :: forall a db . AsDB db => ThentosQuery DB a -> ThentosQuery db a
 polyQuery qry = EitherT . ReaderT $ \ (state :: db) ->
-    runEitherT qry `runReaderT` (state ^. asDB)
+    fmapL asDBThentosError <$> runEitherT qry `runReaderT` (state ^. asDB)

--- a/src/Thentos/Transaction/TH.hs
+++ b/src/Thentos/Transaction/TH.hs
@@ -53,7 +53,7 @@ countArgs (AppT (AppT ArrowT _arg) returnType) = 1 + countArgs returnType
 countArgs _ = 0
 
 -- | Convert e.g. @a -> b -> ThentosUpdate Foo@ to
--- @a -> b -> Update DB (Either ThentosError Foo)@ and check whether it
+-- @a -> b -> Update DB (Either (ThentosError DB) Foo)@ and check whether it
 -- is an Update or a Query.
 makeThentosType :: Type -> (Type, ThentosTransactionType)
 makeThentosType (AppT (AppT ArrowT arg) returnType) =
@@ -72,7 +72,8 @@ makeThentosType (AppT (AppT t (VarT _)) returnType)
 
     makeAcidStateType :: Name -> Type
     makeAcidStateType acidStateTypeConstructor =
-        AppT (AppT (ConT acidStateTypeConstructor) (ConT ''DB)) (AppT (AppT (ConT ''Either) (ConT ''ThentosError)) returnType)
+        AppT (AppT (ConT acidStateTypeConstructor) (ConT ''DB))
+             (AppT (AppT (ConT ''Either) (AppT (ConT ''ThentosError) (ConT ''DB))) returnType)
 makeThentosType (ForallT _ _ app) = makeThentosType app
 makeThentosType t = error $ "not a thentos transaction type: " ++ ppprint t
 

--- a/tests/Thentos/Transaction/CoreSpec.hs
+++ b/tests/Thentos/Transaction/CoreSpec.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TupleSections        #-}
+{-# LANGUAGE TypeFamilies         #-}
 
 module Thentos.Transaction.CoreSpec where
 
@@ -35,6 +36,10 @@ instance AsDB CustomDB where
     asDB :: forall (f :: * -> *). Functor f => (DB -> f DB) -> CustomDB -> f CustomDB
     asDB f (CustomDB db i) = (`CustomDB` i) <$> f db
 
+    asDBThentosError :: ThentosError DB -> ThentosError CustomDB
+    asDBThentosError = CustomDBError
+
+data instance (ThentosError CustomDB) = CustomDBError { fromCustomDBError :: ThentosError DB }
 
 spec_polyQU :: Spec
 spec_polyQU = describe "asDB, polyQuery, polyUpdate" $ do


### PR DESCRIPTION
- turn ThentosError into a data family that can be extended by
  library users.
- this allows trans_..-functions to throw errors in any AsDB type.