### PR TITLE
Proxy module: allow anonymous requests and a default proxy

### DIFF
--- a/devel.config-a3-sample
+++ b/devel.config-a3-sample
@@ -1,0 +1,35 @@
+# Sample config for running A3 with Thentos in proxy mode.
+# Suggested ports: A3 frontend on 6551, Thentos proxy on 6546, A3 backend on 6541.
+
+command: "runA3"
+
+backend:
+    bind_port: 6546
+    bind_host: "127.0.0.1"
+
+#frontend:
+#    bind_port: 7002
+#    bind_host: "127.0.0.1"
+
+proxy:
+    service_id: qlX4MP7xEgtRng+8iNvMIcSo
+    http:
+        bind_port: 6541
+        bind_host: "127.0.0.1"
+
+smtp:
+    sender_name: "Thentos"
+    sender_address: "thentos@thentos.org"
+    sendmail_path: "/usr/sbin/sendmail"    # (built-in default)
+    sendmail_args: ["-t"]                  # (built-in default)
+
+default_user:
+    name: "god"
+    password: "god"
+    email: "postmaster@localhost"
+    roles: ["roleAdmin", "roleUser", "roleServiceAdmin", "roleUserAdmin"]
+
+user_reg_expiration: "1800"
+pw_reset_expiration: "1800"
+email_change_expiration: "1800"
+gc_interval: 1800

--- a/devel.config-a3-sample
+++ b/devel.config-a3-sample
@@ -1,5 +1,5 @@
 # Sample config for running A3 with Thentos in proxy mode.
-# Suggested ports: A3 frontend on 6551, Thentos proxy on 6546, A3 backend on 6541.
+# Used ports: A3 frontend on 6551, Thentos proxy on 6546, A3 backend on 6541.
 
 command: "runA3"
 
@@ -7,9 +7,9 @@ backend:
     bind_port: 6546
     bind_host: "127.0.0.1"
 
-#frontend:
-#    bind_port: 7002
-#    bind_host: "127.0.0.1"
+frontend:
+    bind_port: 6551
+    bind_host: "127.0.0.1"
 
 proxy:
     service_id: qlX4MP7xEgtRng+8iNvMIcSo

--- a/devel.config-a3-sample
+++ b/devel.config-a3-sample
@@ -1,5 +1,9 @@
 # Sample config for running A3 with Thentos in proxy mode.
 # Used ports: A3 frontend on 6551, Thentos proxy on 6546, A3 backend on 6541.
+# Required change in the A3 config:
+# * Change the following line in frontend_development.ini.in:
+#       adhocracy.frontend.rest_url = http://localhost:6546
+# * Call bin/buildout
 
 command: "runA3"
 

--- a/src/Thentos/Action.hs
+++ b/src/Thentos/Action.hs
@@ -82,6 +82,7 @@ import LIO.Error (AnyLabelError)
 
 import qualified Codec.Binary.Base64 as Base64
 import qualified Data.Set as Set
+import qualified Data.Text as ST
 
 import LIO.Missing
 import Thentos.Action.Core
@@ -94,8 +95,10 @@ import qualified Thentos.Transaction as T
 -- * randomness
 
 -- | Return a base64 encoded random string of length 24 (18 bytes of entropy).
+-- We use '_' instead of '/' as last letter of the base64 alphabet since it allows using names
+-- within URLs without percent-encoding.
 freshRandomName :: Action DB ST
-freshRandomName = cs . Base64.encode <$> genRandomBytes'P 18
+freshRandomName = ST.replace "/" "_" . cs . Base64.encode <$> genRandomBytes'P 18
 
 freshConfirmationToken :: Action DB ConfirmationToken
 freshConfirmationToken = ConfirmationToken <$> freshRandomName

--- a/src/Thentos/Action.hs
+++ b/src/Thentos/Action.hs
@@ -95,8 +95,14 @@ import qualified Thentos.Transaction as T
 -- * randomness
 
 -- | Return a base64 encoded random string of length 24 (18 bytes of entropy).
--- We use '_' instead of '/' as last letter of the base64 alphabet since it allows using names
--- within URLs without percent-encoding.
+-- We use @_@ instead of @/@ as last letter of the base64 alphabet since it allows using names
+-- within URLs without percent-encoding. Our Base64 alphabet thus consists of ASCII letters +
+-- digits as well as @+@ and @_@. All of these are reliably recognized in URLs, even if they occur
+-- at the end.
+--
+-- RFC 4648 also has a "URL Safe Alphabet" which additionally replaces @+@ by @-@. But that's
+-- problematic, since @-@ at the end of URLs is not recognized as part of the URL by some programs
+-- such as Thunderbird.
 freshRandomName :: Action DB ST
 freshRandomName = ST.replace "/" "_" . cs . Base64.encode <$> genRandomBytes'P 18
 

--- a/src/Thentos/Backend/Api/Proxy.hs
+++ b/src/Thentos/Backend/Api/Proxy.hs
@@ -112,12 +112,10 @@ getRqMod renderHeaderFun req = do
 -- For convenience, both service ID and target URL are returned.
 findTargetForServiceId :: ServiceId -> ThentosConfig -> Action DB (ServiceId, String)
 findTargetForServiceId sid conf = do
-    target <- case Map.lookup sid proxyMap of
+    target <- case Map.lookup sid (getProxyConfigMap conf) of
             Just proxy -> return $ extractTargetUrl proxy
             Nothing    -> throwError $ ProxyNotConfiguredForService sid
     return (sid, target)
-  where
-    proxyMap :: Map.Map ServiceId ProxyConfig = fromMaybe Map.empty $ getProxyConfigMap conf
 
 -- | Look up the service ID and target URL in the "proxy" section of the config.
 -- An error is thrown if that section is missing.

--- a/src/Thentos/Backend/Api/Proxy.hs
+++ b/src/Thentos/Backend/Api/Proxy.hs
@@ -79,11 +79,17 @@ prepareResp res = S.responseLBS (C.responseStatus res) (C.responseHeaders res) (
 data RqMod = RqMod String T.RequestHeaders
   deriving (Eq, Show)
 
--- | Extract proxy config from thentos config.  Look up session from
--- the token provided in the request header @X-Thentos-Session@ and
--- fill headers @X-Thentos-User@, @X-Thentos-Groups@.  If
--- 'proxyConfig' is 'Nothing' or an invalid or inactive session token
--- is provided, throw an error.
+-- | Create request modifier with custom headers to add to it and the target URL of the
+-- proxied app to forward it to.
+--
+-- If the request contains a @X-Thentos-Service@ header, we find the proxied app based on
+-- this header -- an error is thrown if the "proxies" section of the config doesn't match.
+-- Otherwise, the default proxied app from the "proxy" section of the config is used --
+-- an error is thrown if that section is missing.
+--
+-- If the request contains a @X-Thentos-Session@ header, we validate the session and set the
+-- @X-Thentos-User@ and @X-Thentos-Groups@ headers accordingly. Otherwise the request is
+-- forwarded as an anonymous request (no user logged in).
 --
 -- The first parameter is a function that can be used to rename the Thentos-specific headers.
 -- To stick with the default names, use 'Thentos.Backend.Core.renderThentosHeaderName'.

--- a/src/Thentos/Config.hs
+++ b/src/Thentos/Config.hs
@@ -159,8 +159,8 @@ getConfig configFile = do
 -- the supported leaf types in the config structure.  we hope it'll
 -- get smaller over time.
 
-getProxyConfigMap :: ThentosConfig -> Maybe (Map.Map ServiceId ProxyConfig)
-getProxyConfigMap cfg = (Map.fromList . fmap (exposeKey . Tagged)) <$>
+getProxyConfigMap :: ThentosConfig -> Map.Map ServiceId ProxyConfig
+getProxyConfigMap cfg = fromMaybe Map.empty $ (Map.fromList . fmap (exposeKey . Tagged)) <$>
       cfg >>. (Proxy :: Proxy '["proxies"])
   where
     exposeKey :: ProxyConfig -> (ServiceId, ProxyConfig)

--- a/tests/Test/Config.hs
+++ b/tests/Test/Config.hs
@@ -46,6 +46,7 @@ testThentosConfig tcfg = Tagged $
       :*> JustO (Id (fromTagged testFeConfig))
       :*> JustO (Id (fromTagged testBeConfig))
       :*> NothingO
+      :*> NothingO
       :*> Id (fromTagged testSmtpConfig)
       :*> NothingO
       :*> Id (Timeout 3600)

--- a/tests/Thentos/Backend/Api/Adhocracy3Spec.hs
+++ b/tests/Thentos/Backend/Api/Adhocracy3Spec.hs
@@ -21,7 +21,6 @@ import Data.Aeson (object, (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Functor ((<$>))
 import Data.String.Conversions (LBS, ST, cs, (<>))
-import Network.HTTP.Types.URI (urlEncode)
 import Network.Wai.Test (srequest, simpleStatus, simpleBody)
 import Test.Hspec (Spec, describe, it, before, after, shouldBe, shouldSatisfy, pendingWith, hspec)
 import Test.QuickCheck (property)
@@ -138,11 +137,8 @@ spec =
                         ["-q", "Subject: Thentos account creation", logfile] ""
                     liftIO $ statusCode `shouldBe` ExitSuccess
                     loggedLine <- liftIO $ readProcess "grep" ["\"Please go to ", logfile] ""
-                    -- The grepped line should contain the percent-encoded token (but the case of
-                    --percent-encoded chars may vary, therefore toLower)
-                    let encodedTok = cs . urlEncode True $ cs confTok
-                    liftIO $ ST.toLower encodedTok `shouldSatisfy`
-                        (`ST.isInfixOf` (ST.toLower . cs $ loggedLine))
+                    -- The grepped line should contain the confirmation token
+                    liftIO $ confTok `shouldSatisfy` (`ST.isInfixOf` cs loggedLine)
 
                     let rq2 = Aeson.encode . ActivationRequest . Path $ "/activate/" <> confTok
                     rsp2 <- srequest $ makeSRequest "POST" "/activate_account" [] rq2


### PR DESCRIPTION
* Add support for forwarding requests from users that aren't logged in.
* If no X-Thentos-Service is specified, we use a default proxied app, if  configured (new section in the config).
* Add sample config for running A3 with Thentos in proxy mode.

Part of the ongoing work on #110.