### PR TITLE
Caseless command-name parsing

### DIFF
--- a/thentos-adhocracy/devel.config
+++ b/thentos-adhocracy/devel.config
@@ -5,7 +5,7 @@
 #       adhocracy.frontend.rest_url = http://localhost:6546
 # * Call bin/buildout
 
-command: "runA3"
+command: "run"
 
 backend:
     bind_port: 6546

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -122,8 +122,7 @@ instance Aeson.FromJSON Command
   where
     parseJSON (Aeson.String t) = case ST.toCaseFold t `elemIndex` commands of
         Just idx -> return (toEnum idx :: Command)
-        Nothing  -> fail $ concat ["Unknown command: ", show t, ", expected one of ",
-                                   show ([minBound ..] :: [Command])]
+        Nothing  -> fail $ concat ["Unknown command: ", show t, ", expected one of ", show commands]
       where
         commands = map (ST.toCaseFold . cs . show) ([minBound ..] :: [Command])
     parseJSON bad = fail $ "Command is not a string: " ++ show bad

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -124,7 +124,11 @@ instance Aeson.FromJSON Command
         Just idx -> return (toEnum idx :: Command)
         Nothing  -> fail $ concat ["Unknown command: ", show t, ", expected one of ", show commands]
       where
-        commands = map (ST.toCaseFold . cs . show) ([minBound ..] :: [Command])
+        commands' = map (ST.toCaseFold . cs . show) ([minBound ..] :: [Command])
+        commands = if nub commands' == commands'
+            then commands'
+            else error "internal error: indistinguishable Command constructors (case-insensitive)"
+
     parseJSON bad = fail $ "Command is not a string: " ++ show bad
 
 data HttpSchema = Http | Https

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -17,6 +17,7 @@ import Data.Configifier
     , ToConfigCode, ToConfig, Tagged(Tagged), TaggedM(TaggedM), MaybeO(..), Error
     )
 import Data.Maybe (fromMaybe)
+import Data.List (elemIndex)
 import Data.Proxy (Proxy(Proxy))
 import Data.String.Conversions (ST, cs, (<>))
 import Data.Typeable (Typeable)
@@ -33,6 +34,7 @@ import Text.Show.Pretty (ppShow)
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Map as Map
+import qualified Data.Text as ST
 import qualified Data.Text.IO as ST
 import qualified Generics.Generic.Aeson as Aeson
 
@@ -115,7 +117,16 @@ data Command = Run | RunSso | ShowDB
   deriving (Eq, Ord, Show, Enum, Bounded, Typeable, Generic)
 
 instance Aeson.ToJSON Command where toJSON = Aeson.gtoJson
-instance Aeson.FromJSON Command where parseJSON = Aeson.gparseJson
+
+instance Aeson.FromJSON Command
+  where
+    parseJSON (Aeson.String t) = case ST.toCaseFold t `elemIndex` commands of
+        Just idx -> return (toEnum idx :: Command)
+        Nothing  -> fail $ concat ["Unknown command: ", show t, ", expected one of ",
+                                   show ([minBound ..] :: [Command])]
+      where
+        commands = map (ST.toCaseFold . cs . show) ([minBound ..] :: [Command])
+    parseJSON bad = fail $ "Command is not a string: " ++ show bad
 
 data HttpSchema = Http | Https
   deriving (Eq, Ord, Enum, Bounded, Typeable, Generic)


### PR DESCRIPTION
Fixes #176.

There is now also a nice error message if the specified command is unknown.

I haven't specifically handled the "crash reliably if there are two constructors that are only distinguishable if case sensitively parsed" requirement, but I think if someone defines an enum

    data Command = Run | RuN | ...

that's pathological enough to not deserve special treatment.

The current implementation will simply select the first matching constructor in that case.