### PR TITLE
Type synonym for superset of common class constraints.

### DIFF
--- a/thentos-core/src/Thentos/Backend/Core.hs
+++ b/thentos-core/src/Thentos/Backend/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds                          #-}
 {-# LANGUAGE DataKinds                                #-}
 {-# LANGUAGE DeriveDataTypeable                       #-}
 {-# LANGUAGE ExistentialQuantification                #-}
@@ -53,7 +54,7 @@ import Thentos.Util
 
 -- * action
 
-enterAction :: forall db . (db `Extends` DB, Show (ActionError db), ThentosErrorToServantErr db) =>
+enterAction :: forall db . (db `Ex` DB, ThentosErrorToServantErr db) =>
     ActionState db -> Maybe ThentosSessionToken -> Action db :~> EitherT ServantErr IO
 enterAction state mTok = Nat $ EitherT . run
   where
@@ -71,8 +72,7 @@ enterAction state mTok = Nat $ EitherT . run
 -- thrown.  The error constructors should take all the information in typed form.  Rendering
 -- (e.g. with 'show') and dispatching different parts of the information to differnet log levels and
 -- servant error is the sole responsibility of this function.
-actionErrorToServantErr :: forall db
-       . (db `Extends` DB, Show (ActionError db), ThentosErrorToServantErr db)
+actionErrorToServantErr :: forall db . (db `Ex` DB, ThentosErrorToServantErr db)
       => ActionError db -> IO ServantErr
 actionErrorToServantErr e = do
     logger DEBUG $ ppShow e

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -84,7 +84,6 @@ class ( Typeable dbParent, Typeable dbChild
       , SafeCopy dbParent, SafeCopy dbChild
       , Exception (ThentosError dbParent), Exception (ThentosError dbChild)
       , SafeCopy (ThentosError dbParent), SafeCopy (ThentosError dbChild)
-      , EmptyDB dbChild
       ) =>
         dbChild `Extends` dbParent where
 

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds   #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators     #-}
@@ -6,7 +7,6 @@ module Thentos.Test.Config
 where
 
 import Control.Applicative ((<$>))
-import Control.Exception (Exception)
 import Control.Lens ((^.))
 import Data.Acid (AcidState)
 import Data.Configifier ((:*>)((:*>)), Id(Id), Tagged(Tagged), MaybeO(JustO, NothingO), fromTagged)
@@ -20,6 +20,7 @@ import System.Log.Missing (Prio(Prio))
 
 import Thentos.Types
 import Thentos.Config
+import Thentos.Action.Core (Ex)
 import Thentos (createDefaultUser)
 
 import Thentos.Test.Types
@@ -98,8 +99,7 @@ godName = "god"
 godPass :: UserPass
 godPass = "god"
 
-createGod :: (db `Extends` DB, Exception (ThentosError db), Eq (ThentosError db)) =>
-    AcidState db -> IO ()
+createGod :: (db `Ex` DB) => AcidState db -> IO ()
 createGod st = createDefaultUser st
     (Just . Tagged $
           Id (fromUserName godName)


### PR DESCRIPTION
- Relax constraints of the `Extends` class by not forcing a `EmptyDB` instance.
- Provide a type synonym for actions that makes signatures a lot more readable.
- Use throughout (even where it is more restrictive than necessary).