### PR TITLE
fix csrf test to work with phantomjs

### DIFF
--- a/thentos-core/src/Thentos/Frontend/Handlers.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers.hs
@@ -177,7 +177,7 @@ resetPasswordConfirm = do
             eResult <- snapRunActionE $ A.resetPassword token password
             case eResult of
                 Right () -> do
-                    sendFrontendMsg $ FrontendMsgSuccess "Password changed succesfully.  Welcome back to Thentos!"
+                    sendFrontendMsg $ FrontendMsgSuccess "Password changed successfully.  Welcome back to Thentos!"
 
                     -- FIXME: what we would like to do here is login
                     -- the user right away:

--- a/thentos-core/src/Thentos/Frontend/Handlers.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers.hs
@@ -418,7 +418,7 @@ unknownPath = do
 
 -- * Cache control
 
--- | Disable response caching. The wrapped handled can overwrite this by
+-- | Disable response caching. The wrapped handler can overwrite this by
 -- setting its own cache control headers.
 --
 -- Cache-control headers are only added to GET and HEAD responses since other request methods

--- a/thentos-tests/bench/Main.hs
+++ b/thentos-tests/bench/Main.hs
@@ -34,6 +34,7 @@ import Thentos.Types
     , UserId, ThentosSessionToken(fromThentosSessionToken), UserId(..)
     )
 
+import Thentos.Test.Config (godUid, godPass)
 import Thentos.Test.Core
 import Thentos.Test.Types
 
@@ -86,7 +87,7 @@ getThentosSessionToken :: TestConfig -> IO (Maybe ThentosSessionToken)
 getThentosSessionToken cfg = do
     let (Just req_) = makeEndpoint cfg "/thentos_session"
         req = req_
-                { requestBody = RequestBodyLBS $ encode (UserId 0, UserPass "god")
+                { requestBody = RequestBodyLBS $ encode (godUid, godPass)
                 , method = methodPost
                 }
     withManager $ \m -> do

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -69,8 +69,12 @@ spec_createUser = describe "create user" $ do
         myEmail    = "email@example.com"
 
     it "fill out form." $ \ fts -> do
-        (fts ^. ftsRunWD) $ do
-            WD.openPageSync (cs $ exposeUrl (fts ^. ftsFrontendCfg))
+        let ActionState (st, _, _) = fts ^. ftsActionState
+            feConfig = fts ^. ftsFrontendCfg
+            wd = fts ^. ftsRunWD
+
+        wd $ do
+            WD.openPageSync (cs $ exposeUrl feConfig)
             WD.findElem (WD.ByLinkText "Register new user") >>= WD.clickSync
 
             let fill :: WD.WebDriver wd => ST -> ST -> wd ()
@@ -83,10 +87,6 @@ spec_createUser = describe "create user" $ do
 
             WD.findElem (WD.ById "create_user_submit") >>= WD.clickSync
             WD.getSource >>= \ s -> liftIO $ cs s `shouldSatisfy` (=~# "Please check your email")
-
-        let ActionState (st, _, _) = fts ^. ftsActionState
-            feConfig = fts ^. ftsFrontendCfg
-            wd = fts ^. ftsRunWD
 
         -- check confirmation token in DB.
         Right (db1 :: DB) <- query' st $ SnapShot

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -276,7 +276,7 @@ spec_logInSetsSessionCookie = it "set cookie on login" $ \ fts -> do
     oneSessionCookie _   = False
 
 
--- This is a a webdriver meta-test, as a base case for the csrf test below.
+-- This is a a webdriver meta-test, as a base case for 'spec_failOnCsrf'.
 spec_restoringCookieRestoresSession :: SpecWith (FTS DB)
 spec_restoringCookieRestoresSession = it "restore session by restoring cookie" $ \ fts -> do
     let feConfig = fts ^. ftsFrontendCfg

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -15,7 +15,6 @@ import Data.String.Conversions (ST, cs)
 import Test.Hspec (Spec, SpecWith, describe, it, before, after, shouldBe, shouldSatisfy, hspec, pendingWith)
 
 import qualified Data.Map as Map
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as ST
 import qualified Network.HTTP.Types.Status as C
 import qualified Test.WebDriver as WD

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -16,7 +16,7 @@ import Test.Hspec (Spec, SpecWith, describe, it, before, after, shouldBe, should
 
 import qualified Data.Map as Map
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Text as T
+import qualified Data.Text as ST
 import qualified Network.HTTP.Types.Status as C
 import qualified Test.WebDriver as WD
 import qualified Test.WebDriver.Class as WD
@@ -86,7 +86,7 @@ spec_createUser = describe "create user" $ do
             fill "/user/register.email" myEmail
 
             WD.findElem (WD.ById "create_user_submit") >>= WD.clickSync
-            WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` T.isInfixOf "Please check your email"
+            WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` ST.isInfixOf "Please check your email"
 
         -- check confirmation token in DB.
         Right (db1 :: DB) <- query' st $ SnapShot
@@ -97,7 +97,7 @@ spec_createUser = describe "create user" $ do
         case Map.toList $ db1 ^. dbUnconfirmedUsers of
               [(tok, _)] -> wd $ do
                   WD.openPageSync . cs $ urlConfirm feConfig "/user/register_confirm" (fromConfirmationToken tok)
-                  WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` T.isInfixOf "Registration complete"
+                  WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` ST.isInfixOf "Registration complete"
               bad -> error $ "dbUnconfirmedUsers: " ++ show bad
 
         -- check that user is in db
@@ -214,7 +214,7 @@ spec_logIntoThentos = it "log into thentos" $ \fts -> fts ^. ftsRunWD $ do
     let feConfig = fts ^. ftsFrontendCfg
 
     wdLogin feConfig godName godPass >>= liftIO . (`shouldBe` 200) . C.statusCode
-    WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` T.isInfixOf "Login successful"
+    WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` ST.isInfixOf "Login successful"
 
 
 spec_logOutOfThentos :: SpecWith (FTS DB)
@@ -224,7 +224,7 @@ spec_logOutOfThentos = it "log out of thentos" $ \fts -> fts ^. ftsRunWD $ do
     -- logout when logged in
     wdLogin feConfig godName godPass >>= liftIO . (`shouldBe` 200) . C.statusCode
     wdLogout feConfig >>= liftIO . (`shouldBe` 200) . C.statusCode
-    WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` T.isInfixOf "You have been logged out"
+    WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` ST.isInfixOf "You have been logged out"
 
     -- logout when already logged out
     wdLogout feConfig >>= liftIO . (`shouldBe` 400) . C.statusCode
@@ -298,9 +298,9 @@ spec_serviceCreate = it "service create" $ \fts -> do
     let sname :: ST = "Evil Corp."
         sdescr :: ST = "don't be evil."
         pat = "Service id: "
-        extractId s = case snd . T.breakOn "Service id: " $ s of
+        extractId s = case snd . ST.breakOn "Service id: " $ s of
             "" -> Nothing
-            m  -> Just . ServiceId . T.take 24 . T.drop (T.length pat) $ m
+            m  -> Just . ServiceId . ST.take 24 . ST.drop (ST.length pat) $ m
     serviceId <- wd $ do
         wdLogin feConfig godName godPass >>= liftIO . (`shouldBe` 200) . C.statusCode
         WD.openPageSync (cs $ exposeUrl feConfig <//> "/dashboard/ownservices")
@@ -377,7 +377,7 @@ spec_failOnCsrf =  it "fails on csrf" $ \fts -> fts ^. ftsRunWD $ do
     fill "/dashboard/ownservices.name" "this is a service name"
     fill "/dashboard/ownservices.description" "this is a service description"
     WD.findElem (WD.ById "create_service_submit") >>= WD.clickSync
-    WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` T.isInfixOf "csrf badness"
+    WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` ST.isInfixOf "csrf badness"
 
 
 -- * wd actions
@@ -412,12 +412,12 @@ wdLogout feConfig = do
 isLoggedIn :: HttpConfig -> WD.WD ()
 isLoggedIn cfg = do
         WD.openPageSync (cs $ exposeUrl cfg <//> "/dashboard/details")
-        WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` T.isInfixOf "Thentos Dashboard"
+        WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` ST.isInfixOf "Thentos Dashboard"
 
 isNotLoggedIn :: HttpConfig -> WD.WD ()
 isNotLoggedIn cfg = do
         WD.openPageSync (cs $ exposeUrl cfg <//> "/dashboard/details")
-        WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` T.isInfixOf "Thentos Login"
+        WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` ST.isInfixOf "Thentos Login"
 
 
 -- | Fill a labeled text field.

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE ViewPatterns         #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE ViewPatterns         #-}
 
 {-# OPTIONS -fno-warn-incomplete-patterns #-}
 

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -260,9 +260,9 @@ spec_logInSetsSessionCookie = it "set cookie on login" $ \fts -> do
     let feConfig = fts ^. ftsFrontendCfg
         wd = fts ^. ftsRunWD
     wd $ do
-        WD.cookies >>= \cs -> liftIO $ cs `shouldBe` []
+        WD.cookies >>= \cc -> liftIO $ cc `shouldBe` []
         wdLogin feConfig godName godPass >>= liftIO . (`shouldBe` 200) . C.statusCode
-        WD.cookies >>= \cs -> liftIO $ cs `shouldSatisfy` oneSessionCookie
+        WD.cookies >>= \cc -> liftIO $ cc `shouldSatisfy` oneSessionCookie
   where
     oneSessionCookie [c] = WD.cookName c == "sess" && WD.cookPath c == Just "/"
     oneSessionCookie _   = False
@@ -284,7 +284,7 @@ spec_restoringCookieRestoresSession = it "restore session by restoring cookie" $
         -- With phantomjs, the store/delete/set cycle adds a leading dot to the cookie
         -- domain, and the dashboard request inside 'isLoggedin' above sets
         -- the updated cookie, so we end up with two cookies.
-        -- WD.cookies >>= \cs -> liftIO $ length cs `shouldBe` 1
+        -- WD.cookies >>= \cc -> liftIO $ length cc `shouldBe` 1
 
 
 spec_serviceCreate :: SpecWith (FTS DB)

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -283,13 +283,12 @@ spec_restoringCookieRestoresSession = it "restore session by restoring cookie" $
         WD.deleteVisibleCookies
         mapM_ WD.setCookie cookies
 
-        WD.openPageSync (cs $ exposeUrl feConfig <//> "/dashboard/details")
-        WD.getSource >>= \ s -> liftIO $ cs s `shouldSatisfy` (=~# "Thentos Dashboard")
+        isLoggedIn feConfig
 
         -- With phantomjs, the store/delete/set cycle adds a leading dot to the cookie
-        -- domain, and the dashboard request above sets the updated cookie, so we
-        -- end up with two cookies.
-        -- WD.cookies >>= \ cs -> liftIO $ length cs `shouldBe` 1
+        -- domain, and the dashboard request inside 'isLoggedin' above sets
+        -- the updated cookie, so we end up with two cookies.
+        -- WD.cookies >>= \cs -> liftIO $ length cs `shouldBe` 1
 
 
 spec_serviceCreate :: SpecWith (FTS DB)
@@ -414,3 +413,14 @@ wdLogout feConfig = do
     buttonIsThere el = do
         WD.clickSync el
         return $ C.Status 200 "Ok."  -- FIXME: as in wdLogin
+
+
+isLoggedIn :: HttpConfig -> WD.WD ()
+isLoggedIn cfg = do
+        WD.openPageSync (cs $ exposeUrl cfg <//> "/dashboard/details")
+        WD.getSource >>= \s -> liftIO $ cs s `shouldSatisfy` (=~# "Thentos Dashboard")
+
+isNotLoggedIn :: HttpConfig -> WD.WD ()
+isNotLoggedIn cfg = do
+        WD.openPageSync (cs $ exposeUrl cfg <//> "/dashboard/details")
+        WD.getSource >>= \s -> liftIO $ cs s `shouldSatisfy` (=~# "Thentos Login")

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -214,10 +214,6 @@ spec_logIntoThentos = it "log into thentos" $ \ fts -> fts ^. ftsRunWD $ do
     wdLogin feConfig "god" "god" >>= liftIO . (`shouldBe` 200) . C.statusCode
     WD.getSource >>= \ s -> liftIO $ cs s `shouldSatisfy` (=~# "Login successful")
 
-    -- (out of curiousity: why do we need the type signature in the
-    -- lambda parameter?  shouldn't ghc infer (and be happy with the
-    -- fact) that the lambda is polymorphic in all places where it
-    -- takes '_'?)
 
 spec_logOutOfThentos :: SpecWith (FTS DB)
 spec_logOutOfThentos = it "log out of thentos" $ \ fts -> fts ^. ftsRunWD $ do

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -80,9 +80,6 @@ spec_createUser = describe "create user" $ do
             WD.openPageSync (cs $ exposeUrl feConfig)
             WD.findElem (WD.ByLinkText "Register new user") >>= WD.clickSync
 
-            let fill :: WD.WebDriver wd => ST -> ST -> wd ()
-                fill label text = WD.findElem (WD.ById label) >>= WD.sendKeys text
-
             fill "/user/register.name" myUsername
             fill "/user/register.password1" myPassword
             fill "/user/register.password2" myPassword
@@ -304,9 +301,6 @@ spec_serviceCreate = it "service create" $ \fts -> do
         wdLogin feConfig "god" "god" >>= liftIO . (`shouldBe` 200) . C.statusCode
         WD.openPageSync (cs $ exposeUrl feConfig <//> "/dashboard/ownservices")
 
-        let fill :: WD.WebDriver wd => ST -> ST -> wd ()
-            fill label text = WD.findElem (WD.ById label) >>= WD.sendKeys text
-
         fill "/dashboard/ownservices.name" sname
         fill "/dashboard/ownservices.description" sdescr
 
@@ -375,9 +369,6 @@ spec_failOnCsrf =  it "fails on csrf" $ \fts -> fts ^. ftsRunWD $ do
     WD.openPageSync (cs $ exposeUrl feConfig <//> "/dashboard/ownservices")
     WD.deleteVisibleCookies -- delete before restore to work around phantomjs domain wonkiness
     mapM_ WD.setCookie storedCookies
-    let fill :: WD.WebDriver wd => ST -> ST -> wd ()
-        fill label text = WD.findElem (WD.ById label) >>= WD.sendKeys text
-
     fill "/dashboard/ownservices.name" "this is a service name"
     fill "/dashboard/ownservices.description" "this is a service description"
     WD.findElem (WD.ById "create_service_submit") >>= WD.clickSync
@@ -391,8 +382,6 @@ wdLogin feConfig (UserName uname) (UserPass upass) = do
     WD.setImplicitWait 200
     WD.openPageSync (cs $ exposeUrl feConfig <//> "/user/login")
 
-    let fill :: WD.WebDriver wd => ST -> ST -> wd ()
-        fill label text = WD.findElem (WD.ById label) >>= WD.sendKeys text
     fill "/user/login.name" uname
     fill "/user/login.password" upass
 
@@ -424,3 +413,8 @@ isNotLoggedIn :: HttpConfig -> WD.WD ()
 isNotLoggedIn cfg = do
         WD.openPageSync (cs $ exposeUrl cfg <//> "/dashboard/details")
         WD.getSource >>= \s -> liftIO $ cs s `shouldSatisfy` (=~# "Thentos Login")
+
+
+-- | Fill a labeled text field.
+fill :: WD.WebDriver wd => ST -> ST -> wd ()
+fill label text = WD.findElem (WD.ById label) >>= WD.sendKeys text

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -47,6 +47,7 @@ spec = describe "selenium grid" $ do
     spec_logOutOfThentos
     spec_redirectWhenNotLoggedIn
     spec_dontRedirectWhenLoggedIn
+    spec_deletingCookiesLogsOut
     spec_serviceCreate
     spec_serviceDelete
     spec_serviceUpdateMetadata
@@ -247,6 +248,17 @@ spec_dontRedirectWhenLoggedIn = it "don't redirect to login page" $ \ fts -> do
         wdLogin feConfig "god" "god" >>= liftIO . (`shouldBe` 200) . C.statusCode
         WD.openPageSync (cs $ exposeUrl feConfig <//> "/dashboard/details")
         WD.getSource >>= \ s -> liftIO $ cs s `shouldSatisfy` (=~# "Thentos Dashboard")
+
+
+spec_deletingCookiesLogsOut :: SpecWith (FTS DB)
+spec_deletingCookiesLogsOut = it "log out by deleting cookies" $ \ fts -> do
+    let feConfig = fts ^. ftsFrontendCfg
+        wd = fts ^. ftsRunWD
+    wd $ do
+        wdLogin feConfig "god" "god" >>= liftIO . (`shouldBe` 200) . C.statusCode
+        WD.deleteVisibleCookies
+        WD.openPageSync (cs $ exposeUrl feConfig <//> "/dashboard/details")
+        WD.getSource >>= \ s -> liftIO $ cs s `shouldSatisfy` (=~# "Thentos Login")
 
 
 spec_serviceCreate :: SpecWith (FTS DB)

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -378,6 +378,7 @@ spec_failOnCsrf =  it "fails on csrf" $ \ fts -> fts ^. ftsRunWD $ do
     WD.deleteVisibleCookies
     wdLogin feConfig (UserName "god") (UserPass "god") >>= liftIO . (`shouldBe` 200) . C.statusCode
     WD.openPageSync (cs $ exposeUrl feConfig <//> "/dashboard/ownservices")
+    WD.deleteVisibleCookies -- delete before restore to work around phantomjs domain wonkiness
     mapM_ WD.setCookie storedCookies
     let fill :: WD.WebDriver wd => ST -> ST -> wd ()
         fill label text = WD.findElem (WD.ById label) >>= WD.sendKeys text


### PR DESCRIPTION
Fixes #232. Adds a couple of very basic tests related to login and cookies. Plus two typos or so.