### PR TITLE
Move sso-related db fields, transactions and actions into thentos-adhocracy

### DIFF
--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
@@ -59,6 +59,7 @@ import Thentos.Backend.Api.Proxy (ServiceProxy, serviceProxy)
 import Thentos.Backend.Core
 import Thentos.Config
 import Thentos.Util
+import Thentos.Adhocracy3.Transactions ()
 
 import qualified Thentos.Action as A
 import qualified Thentos.Action.Core as AC

--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Transactions.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Transactions.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE InstanceSigs          #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-# OPTIONS -fno-warn-orphans #-}
+
+module Thentos.Adhocracy3.Transactions where
+
+import Control.Applicative ((<$>))
+import Control.Lens ((%~), (^.))
+import Control.Monad (unless)
+import Control.Monad.State (get, modify)
+import Data.EitherR (throwT)
+
+import Thentos.Adhocracy3.Types
+import Thentos.Transaction.Core
+import Thentos.Transaction.TH
+
+import qualified Data.Set as Set
+
+import qualified Thentos.Transaction as CoreTransaction
+import qualified Thentos.Types as CoreTypes
+
+
+-- * SSO
+
+-- | Add an SSO token to the database
+trans_addSsoToken :: (db `Extends` DB) => SsoToken -> ThentosUpdate db ()
+trans_addSsoToken tok = polyUpdate . modify $ dbSsoTokens %~ Set.insert tok
+
+-- | Remove an SSO token from the database. Throw NoSuchToken if the token doesn't exist.
+trans_lookupAndRemoveSsoToken :: (db `Extends` DB) => SsoToken -> ThentosUpdate db ()
+trans_lookupAndRemoveSsoToken tok = polyUpdate $ do
+    exists <- Set.member tok . (^. dbSsoTokens) <$> get
+    unless exists $ throwT SsoErrorUnknownCsrfToken
+    modify $ dbSsoTokens %~ Set.delete tok
+
+$(makeThentosAcidicPhase1 ''DB ['trans_addSsoToken, 'trans_lookupAndRemoveSsoToken])
+$(makeThentosAcidicPhase2 ''DB
+                          ['trans_addSsoToken, 'trans_lookupAndRemoveSsoToken]
+                          [''CoreTypes.DB]
+                          ['CoreTransaction.dbEvents])

--- a/thentos-adhocracy/thentos-adhocracy.cabal
+++ b/thentos-adhocracy/thentos-adhocracy.cabal
@@ -41,6 +41,7 @@ library
     , Thentos.Adhocracy3.Backend.Api.Docs.Simple
     , Thentos.Adhocracy3.Backend.Api.Simple
     , Thentos.Adhocracy3.Backend.Api.Sso
+    , Thentos.Adhocracy3.Transactions
     , Thentos.Adhocracy3.Types
   build-depends:
       base

--- a/thentos-core/src/Thentos/Action.hs
+++ b/thentos-core/src/Thentos/Action.hs
@@ -18,7 +18,6 @@ module Thentos.Action
     , freshServiceKey
     , freshSessionToken
     , freshServiceSessionToken
-    , freshSsoToken
 
     , allUserIds
     , lookupUser
@@ -67,9 +66,6 @@ module Thentos.Action
     , assignRole
     , unassignRole
     , agentRoles
-
-    , addNewSsoToken
-    , lookupAndRemoveSsoToken
 
     , collectGarbage
     )
@@ -132,10 +128,6 @@ freshSessionToken = ThentosSessionToken <$> freshRandomName
 
 freshServiceSessionToken :: Action db ServiceSessionToken
 freshServiceSessionToken = ServiceSessionToken <$> freshRandomName
-
-freshSsoToken :: Action db SsoToken
-freshSsoToken = SsoToken <$> freshRandomName
-
 
 -- * user
 
@@ -596,23 +588,6 @@ agentRoles :: (db `Ex` DB) => Agent -> Action db [Role]
 agentRoles agent = do
     taintMsg "agentRoles" (RoleAdmin \/ agent %% RoleAdmin /\ agent)
     Set.toList <$> query'P (T.AgentRoles agent)
-
-
--- * SSO
-
--- | This doesn't check any labels because it needs to be called as part of the
--- authentication process.
-addNewSsoToken :: (db `Ex` DB, Exception (ActionError db)) => Action db SsoToken
-addNewSsoToken = do
-    tok <- freshSsoToken
-    update'P $ T.AddSsoToken tok
-    return tok
-
--- | This doesn't check any labels because it needs to be called as part of the
--- authentication process.
-lookupAndRemoveSsoToken :: (db `Ex` DB, Exception (ActionError db)) =>
-    SsoToken -> Action db ()
-lookupAndRemoveSsoToken tok = update'P $ T.LookupAndRemoveSsoToken tok
 
 
 -- * garbage collection

--- a/thentos-core/src/Thentos/Backend/Core.hs
+++ b/thentos-core/src/Thentos/Backend/Core.hs
@@ -142,13 +142,6 @@ instance ThentosErrorToServantErr DB where
         f (MalformedUserPath path) =
             (Nothing, err400 { errBody = "malformed user path: " <> cs (show path) })
 
-        -- the following shouldn't actually reach servant:
-        f SsoErrorUnknownCsrfToken =
-            (Just (ERROR, show e), err500 { errBody = "invalid token returned during sso process" })
-        f (SsoErrorCouldNotAccessUserInfo _) =
-            (Just (ERROR, show e), err500 { errBody = "error accessing user info" })
-        f (SsoErrorCouldNotGetAccessToken _) =
-            (Just (ERROR, show e), err500 { errBody = "error retrieving access token" })
 
 -- * custom servers for servant
 

--- a/thentos-core/src/Thentos/Transaction/Transactions.hs
+++ b/thentos-core/src/Thentos/Transaction/Transactions.hs
@@ -519,20 +519,6 @@ trans_agentRoles :: (db `Extends` DB) => Agent -> ThentosQuery db (Set.Set Role)
 trans_agentRoles agent = polyQuery $ fromMaybe Set.empty . Map.lookup agent . (^. dbRoles) <$> ask
 
 
--- * SSO
-
--- | Add an SSO token to the database
-trans_addSsoToken :: (db `Extends` DB) => SsoToken -> ThentosUpdate db ()
-trans_addSsoToken tok = polyUpdate . modify $ dbSsoTokens %~ Set.insert tok
-
--- | Remove an SSO token from the database. Throw NoSuchToken if the token doesn't exist.
-trans_lookupAndRemoveSsoToken :: (db `Extends` DB) => SsoToken -> ThentosUpdate db ()
-trans_lookupAndRemoveSsoToken tok = polyUpdate $ do
-    exists <- Set.member tok . (^. dbSsoTokens) <$> get
-    unless exists $ throwT SsoErrorUnknownCsrfToken
-    modify $ dbSsoTokens %~ Set.delete tok
-
-
 -- * misc
 
 trans_snapShot :: (db `Extends` DB) => ThentosQuery db DB
@@ -628,8 +614,6 @@ transaction_names =
     , 'trans_assignRole
     , 'trans_unassignRole
     , 'trans_agentRoles
-    , 'trans_addSsoToken
-    , 'trans_lookupAndRemoveSsoToken
     , 'trans_snapShot
     , 'trans_garbageCollectThentosSessions
     , 'trans_doGarbageCollectThentosSessions

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -77,7 +77,6 @@ data DB =
       , _dbUnconfirmedUsers  :: !(Map ConfirmationToken  ((UserId, User),      Timestamp))
       , _dbPwResetTokens     :: !(Map PasswordResetToken ( UserId,             Timestamp))
       , _dbEmailChangeTokens :: !(Map ConfirmationToken  ((UserId, UserEmail), Timestamp))
-      , _dbSsoTokens         :: !(Set SsoToken)
       , _dbFreshUserId       :: !UserId
       }
   deriving (Eq, Show, Typeable, Generic)
@@ -111,7 +110,7 @@ class EmptyDB db where
     emptyDB :: db
 
 instance EmptyDB DB where
-    emptyDB = DB m m m m m m m m m m Set.empty (UserId 0)
+    emptyDB = DB m m m m m m m m m m (UserId 0)
       where m = Map.empty
 
 
@@ -202,10 +201,6 @@ newtype ConfirmationToken = ConfirmationToken { fromConfirmationToken :: ST }
 
 newtype PasswordResetToken = PasswordResetToken { fromPasswordResetToken :: ST }
     deriving (Eq, Ord, Show, Read, Typeable, Generic)
-
-newtype SsoToken = SsoToken { fromSsoToken :: ST }
-    deriving (Eq, Ord, Show, Read, Typeable, Generic)
-
 
 -- | Information required to create a new User
 data UserFormData =
@@ -487,9 +482,6 @@ data instance ThentosError DB =
     | NoSuchToken
     | NeedUserA ThentosSessionToken ServiceId
     | MalformedUserPath ST
-    | SsoErrorUnknownCsrfToken
-    | SsoErrorCouldNotAccessUserInfo LBS
-    | SsoErrorCouldNotGetAccessToken LBS
 
 deriving instance Eq (ThentosError DB)
 deriving instance Show (ThentosError DB)
@@ -535,4 +527,3 @@ $(deriveSafeCopy 0 'base ''ThentosSessionToken)
 $(deriveSafeCopy 0 'base ''User)
 $(deriveSafeCopy 0 'base ''UserId)
 $(deriveSafeCopy 0 'base ''UserName)
-$(deriveSafeCopy 0 'base ''SsoToken)


### PR DESCRIPTION
This is basically a refactoring for #212 , but since it's nice and self-contained I'd like to merge it before the actual implementation work.