### PR TITLE
Fix X-User-Path contents for A3

### DIFF
--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Sso.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Sso.hs
@@ -137,7 +137,7 @@ api :: Client.Manager -> AC.ActionState DB -> Server Api
 api manager actionState =
        thentosA3Sso  actionState
   :<|> thentosApi404 actionState
-  :<|> serviceProxy manager A3.renderA3HeaderName actionState
+  :<|> serviceProxy manager A3.a3ProxyAdapter actionState
 
 
 -- * handler

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -29,7 +29,7 @@ import Data.Monoid ((<>))
 import Data.SafeCopy (SafeCopy, Contained, deriveSafeCopy, base, contain, putCopy, getCopy,
                       safePut, safeGet)
 import Data.Set (Set)
-import Data.String.Conversions (SBS, LBS, ST, cs)
+import Data.String.Conversions (SBS, ST, cs)
 import Data.String (IsString)
 import Data.Thyme.Time () -- required for NominalDiffTime's num instance
 import Data.Thyme (UTCTime, NominalDiffTime, formatTime, parseTime, toSeconds, fromSeconds)
@@ -47,7 +47,6 @@ import URI.ByteString (uriAuthority, uriQuery, uriScheme, schemeBS, uriFragment,
 import qualified Crypto.Scrypt as Scrypt
 import qualified Data.Aeson as Aeson
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import qualified Data.Serialize as Cereal
 import qualified Generics.Generic.Aeson as Aeson
 


### PR DESCRIPTION
We didn't sent the X-User-Path  (X-Thentos-User) header in the format understood by the A3 backend.

A3 expects something like

    X-User-Path: http://127.0.0.1:6546/principals/users/0000001

but we sent the user name instead.

Fixed by adding a ProxyAdapter that makes the proxy more configurable, and by defining a suitable renderUser function for A3.