### PR TITLE
Change default values to give users more time to click on confirm links

### DIFF
--- a/thentos-adhocracy/devel.config
+++ b/thentos-adhocracy/devel.config
@@ -31,9 +31,9 @@ default_user:
     email: "postmaster@localhost"
     roles: ["roleAdmin", "roleUser", "roleServiceAdmin", "roleUserAdmin"]
 
-user_reg_expiration: "1800"
-pw_reset_expiration: "1800"
-email_change_expiration: "1800"
+user_reg_expiration: "86400"
+pw_reset_expiration: "86400"
+email_change_expiration: "86400"
 gc_interval: 1800
 
 log:

--- a/thentos-core/devel.config
+++ b/thentos-core/devel.config
@@ -20,9 +20,9 @@ default_user:
     email: "postmaster@localhost"
     roles: ["roleAdmin", "roleUser", "roleServiceAdmin", "roleUserAdmin"]
 
-user_reg_expiration: "1800"
-pw_reset_expiration: "1800"
-email_change_expiration: "1800"
+user_reg_expiration: "86400"
+pw_reset_expiration: "86400"
+email_change_expiration: "86400"
 gc_interval: 1800
 
 log:


### PR DESCRIPTION
New default is one day for user registration, password reset and email change.