### PR TITLE
Improve config and logging

### DIFF
--- a/thentos-adhocracy/devel.config
+++ b/thentos-adhocracy/devel.config
@@ -9,15 +9,15 @@ command: "run"
 
 backend:
     bind_port: 6546
-    bind_host: "127.0.0.1"
+    bind_host: localhost
 
 frontend:
     bind_port: 6551
-    bind_host: "127.0.0.1"
+    bind_host: localhost
 
 proxy:
     service_id: qlX4MP7xEgtRng+8iNvMIcSo
-    endpoint: http://127.0.0.1:6541
+    endpoint: http://localhost:6541
 
 smtp:
     sender_name: "Thentos"

--- a/thentos-core/src/Thentos/Backend/Api/Proxy.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Proxy.hs
@@ -127,8 +127,11 @@ getRqMod adapter req = do
 
     hdrs <- createCustomHeaders adapter mTok sid
     let rqMod = RqMod target hdrs
-    logger'P DEBUG $ "forwarding proxy request with modifier: " ++ show rqMod
+    logger'P DEBUG $ concat
+        ["forwarding proxy request ", cs showReqInfo, " with modifier: ", show rqMod]
     return rqMod
+  where
+    showReqInfo = BSC.concat [S.requestMethod req, " ", S.rawPathInfo req, S.rawQueryString req]
 
 -- | Look up the target URL for requests based on the given service ID. This requires a "proxies"
 -- section in the config. An error is thrown if this section is missing or doesn't contain a match.


### PR DESCRIPTION
A3 uses "localhost" in the config hence we must too. Otherwise the A3 frontend won't strip the prefix from user names, leading to errors.

Improve logging by showing request method and path+query string.