### PR TITLE
A3 style error handling

### DIFF
--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Types.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Types.hs
@@ -26,13 +26,16 @@ module Thentos.Adhocracy3.Types
 import Control.Applicative ((<$>))
 import Control.Exception (Exception)
 import Control.Lens (makeLenses)
+import Data.Aeson (Value(String), ToJSON(toJSON), (.=), encode, object)
 import Data.Data (Typeable)
+import Data.Maybe (fromMaybe)
 import Data.SafeCopy (SafeCopy, deriveSafeCopy, base, putCopy, getCopy)
 import Data.Set (Set)
 import Data.String.Conversions (LBS, ST)
 import Data.Thyme.Time () -- required for NominalDiffTime's num instance
 import GHC.Generics (Generic)
-import Servant.Server.Internal.ServantErr (err500)
+import Servant.Server (ServantErr)
+import Servant.Server.Internal.ServantErr (err400, err500, errBody, errHeaders)
 import System.Log.Logger (Priority(ERROR))
 
 import Thentos.Backend.Core
@@ -82,20 +85,81 @@ instance SafeCopy (ThentosError DB)
     putCopy = putCopyViaShowRead
     getCopy = getCopyViaShowRead
 
-instance ThentosErrorToServantErr DB where
-    thentosErrorToServantErr (ThentosA3ErrorCore e) = thentosErrorToServantErr e
-    thentosErrorToServantErr e@(A3BackendErrorResponse _ _) =
-        (Just (ERROR, show e), mkServantErr err500 "exception in a3 backend")
+data A3ErrorInfo = A3ErrorInfo
+    { aeName        :: ST
+    , aeLocation    :: ST
+    , aeDescription :: ST
+    } deriving (Eq, Show)
 
-    thentosErrorToServantErr e@(A3BackendInvalidJson _) = do
-        (Just (ERROR, show e), mkServantErr err500 "exception in a3 backend: received bad json")
-    -- the following shouldn't actually reach servant:
-    thentosErrorToServantErr e@SsoErrorUnknownCsrfToken =
-        (Just (ERROR, show e), mkServantErr err500 "invalid token returned during sso process")
-    thentosErrorToServantErr e@(SsoErrorCouldNotAccessUserInfo _) =
-        (Just (ERROR, show e), mkServantErr err500 "error accessing user info")
-    thentosErrorToServantErr e@(SsoErrorCouldNotGetAccessToken _) =
-        (Just (ERROR, show e), mkServantErr err500 "error retrieving access token")
+instance ToJSON A3ErrorInfo where
+    toJSON err = object
+        [ "status" .= String "error"
+        , "errors" .= [ object
+            [ "name"        .= aeName err
+            , "location"    .= aeLocation err
+            , "description" .= aeDescription err
+            ]]
+        ]
+
+-- Construct a simple A3-style error, with 'aeName' set to "thentos" and 'aeLocation' set to "body".
+-- Useful for cases where all we really have is a description.
+mkSimpleA3ErrorInfo :: ST -> A3ErrorInfo
+mkSimpleA3ErrorInfo desc = A3ErrorInfo
+    {aeName = "thentos", aeLocation = "body", aeDescription = desc}
+
+-- | Construct a ServantErr that looks like those reponrted by the A3 backend.
+-- The backend returns a list of errors but we always use a single-element list, as Thentos
+-- aborts at the first detected error.
+mkA3StyleServantErr :: ServantErr -> A3ErrorInfo -> ServantErr
+mkA3StyleServantErr baseErr errorInfo = baseErr
+    {errBody = encode errorInfo, errHeaders = [contentTypeJsonHeader]}
+
+-- | Construct a simple A3-style 'ServantErr' from only a base error and a message, setting the
+-- other A3-specific fields to default values.
+mkSimpleA3StyleServantErr :: MkServantErrFun
+mkSimpleA3StyleServantErr baseErr msg = mkA3StyleServantErr baseErr $ mkSimpleA3ErrorInfo msg
+
+instance ThentosErrorToServantErr DB where
+    thentosErrorToServantErr mMkErr = f
+      where
+        mkErr = fromMaybe mkSimpleA3StyleServantErr mMkErr
+
+        -- For errors specifically relevant to the A3 frontend we mirror the A3 backend errors
+        -- exactly so that the frontend recognizes them
+        f (ThentosA3ErrorCore e) = case e of
+            BadCredentials -> (Nothing, mkA3StyleServantErr err400 $ A3ErrorInfo
+                "password"
+                "body"
+                "User doesn't exist or password is wrong")
+            UserEmailAlreadyExists -> (Nothing, mkA3StyleServantErr err400 $ A3ErrorInfo
+                "data.adhocracy_core.sheets.principal.IUserExtended.email"
+                "body"
+                "The user login email is not unique")
+            UserNameAlreadyExists -> (Nothing, mkA3StyleServantErr err400 $ A3ErrorInfo
+                "data.adhocracy_core.sheets.principal.IUserBasic.name"
+                "body"
+                "The user login name is not unique")
+            NoSuchPendingUserConfirmation -> (Nothing, mkA3StyleServantErr err400 $ A3ErrorInfo
+                "path"
+                "body"
+                "Unknown or expired activation path")
+            NoSuchThentosSession -> (Nothing, mkA3StyleServantErr err400 $ A3ErrorInfo
+                "X-User-Token"
+                "header"
+                "Invalid user token")
+            _ -> thentosErrorToServantErr (Just mkErr) e
+
+        f e@(A3BackendErrorResponse _ _) =
+            (Just (ERROR, show e), mkErr err500 "exception in a3 backend")
+        f e@(A3BackendInvalidJson _) =
+            (Just (ERROR, show e), mkErr err500 "exception in a3 backend: received bad json")
+        -- the following shouldn't actually reach servant:
+        f e@SsoErrorUnknownCsrfToken =
+            (Just (ERROR, show e), mkErr err500 "invalid token returned during sso process")
+        f e@(SsoErrorCouldNotAccessUserInfo _) =
+            (Just (ERROR, show e), mkErr err500 "error accessing user info")
+        f e@(SsoErrorCouldNotGetAccessToken _) =
+            (Just (ERROR, show e), mkErr err500 "error retrieving access token")
 
 newtype SsoToken = SsoToken { fromSsoToken :: ST }
     deriving (Eq, Ord, Show, Read, Typeable, Generic)


### PR DESCRIPTION
This makes adhocracy-thentos emit errors that like looks those from the A3 backend, so that the frontend will understand them. For all typical error situations that can occur with user creation, account activation, or login, the errors mimic those from the backend exactly.

This means that not only the happy path, but also the usual unhappy paths now work as they should without requiring any further changes at the side of A3.