### PR TITLE
generalized error type

### DIFF
--- a/thentos-core/src/Thentos/Backend/Api/Simple.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Simple.hs
@@ -46,7 +46,7 @@ serveApi = addCacheControlHeaders . serve (Proxy :: Proxy Api) . api
 type Api = ThentosAssertHeaders :> ThentosAuth :> ThentosBasic
 
 api :: ActionState -> Server Api
-api actionState mTok = enter (enterAction actionState mTok) thentosBasic
+api actionState mTok = enter (enterAction actionState baseActionErrorToServantErr mTok) thentosBasic
 
 
 -- * combinators
@@ -57,7 +57,7 @@ type ThentosBasic =
   :<|> "thentos_session" :> ThentosThentosSession
   :<|> "service_session" :> ThentosServiceSession
 
-thentosBasic :: ServerT ThentosBasic Action
+thentosBasic :: ServerT ThentosBasic (Action ())
 thentosBasic =
        thentosUser
   :<|> thentosService
@@ -76,7 +76,7 @@ type ThentosUser =
   :<|> Capture "uid" UserId :> "email" :> Get '[JSON] UserEmail
   :<|> Get '[JSON] [UserId]
 
-thentosUser :: ServerT ThentosUser Action
+thentosUser :: ServerT ThentosUser (Action ())
 thentosUser =
        addUser
   :<|> deleteUser
@@ -99,7 +99,7 @@ type ThentosService =
   :<|> Capture "sid" ServiceId :> Delete '[JSON] ()
   :<|> Get '[JSON] [ServiceId]
 
-thentosService :: ServerT ThentosService Action
+thentosService :: ServerT ThentosService (Action ())
 thentosService =
          (\ (uid, sn, sd) -> addService (UserA uid) sn sd)
     :<|> deleteService
@@ -114,7 +114,7 @@ type ThentosThentosSession =
   :<|> ReqBody '[JSON] ThentosSessionToken     :> Get '[JSON] Bool
   :<|> ReqBody '[JSON] ThentosSessionToken     :> Delete '[JSON] ()
 
-thentosThentosSession :: ServerT ThentosThentosSession Action
+thentosThentosSession :: ServerT ThentosThentosSession (Action ())
 thentosThentosSession =
        uncurry startThentosSessionByUserId
   :<|> uncurry startThentosSessionByServiceId
@@ -129,7 +129,7 @@ type ThentosServiceSession =
   :<|> ReqBody '[JSON] ServiceSessionToken :> "meta" :> Get '[JSON] ServiceSessionMetadata
   :<|> ReqBody '[JSON] ServiceSessionToken :> Delete '[JSON] ()
 
-thentosServiceSession :: ServerT ThentosServiceSession Action
+thentosServiceSession :: ServerT ThentosServiceSession (Action ())
 thentosServiceSession =
        existsServiceSession
   :<|> getServiceSessionMetadata

--- a/thentos-core/src/Thentos/Backend/Core.hs
+++ b/thentos-core/src/Thentos/Backend/Core.hs
@@ -19,7 +19,7 @@
 module Thentos.Backend.Core
 where
 
-import Control.Applicative ((<$>), pure)
+import Control.Applicative ((<$>))
 import Control.Lens ((&), (.~))
 import Control.Monad.Trans.Either (EitherT(EitherT))
 import Data.Aeson (Value(String), ToJSON(toJSON), (.=), encode, object)
@@ -27,13 +27,11 @@ import Data.CaseInsensitive (CI, mk, foldCase, foldedCase)
 import Data.Configifier ((>>.))
 import Data.Function (on)
 import Data.List (nubBy)
-import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy(Proxy))
 import Data.String.Conversions (SBS, ST, cs, (<>))
 import Data.String (fromString)
 import Data.Text.Encoding (decodeUtf8')
 import Data.Typeable (Typeable)
-import LIO.Error (AnyLabelError)
 import Network.HTTP.Types (Header, methodGet, methodHead, methodPost, ok200, status400)
 import Network.Wai (Application, Middleware, Request, requestHeaders, requestMethod)
 import Network.Wai.Handler.Warp (runSettings, setHost, setPort, defaultSettings)
@@ -61,14 +59,18 @@ import Thentos.Util
 
 -- * action
 
-enterAction :: 
-    ActionState -> Maybe ThentosSessionToken -> Action :~> EitherT ServantErr IO
-enterAction state mTok = Nat $ EitherT . run
+enterAction :: (Show e, Typeable e) =>
+    ActionState ->
+    (ActionError e -> IO ServantErr) ->
+    Maybe ThentosSessionToken -> Action e :~> EitherT ServantErr IO
+enterAction state toServantErr mTok = Nat $ EitherT . (run toServantErr)
   where
-    run :: Action a -> IO (Either ServantErr a)
-    run = (>>= fmapLM actionErrorToServantErr) . runActionE state . updatePrivs mTok
+    run :: (Show e, Typeable e)
+        => (ActionError e -> IO ServantErr)
+        -> Action e a -> IO (Either ServantErr a)
+    run e = (>>= fmapLM e) . runActionE state . updatePrivs mTok
 
-    updatePrivs :: Maybe ThentosSessionToken -> Action a -> Action a
+    updatePrivs :: Maybe ThentosSessionToken -> Action e a -> Action e a
     updatePrivs (Just tok) action = (accessRightsByThentosSession'P tok >>= grantAccessRights'P) >> action
     updatePrivs Nothing    action = action
 
@@ -81,15 +83,14 @@ newtype ErrorMessage = ErrorMessage { fromErrorMessage :: ST }
 instance ToJSON ErrorMessage where
     toJSON (ErrorMessage msg) = object ["status" .= String "error", "error" .= msg]
 
--- |Type of functions that transform a base error and an error message into a ServantErr.
-type MkServantErrFun = ServantErr -> ST -> ServantErr
-
 -- | Construct a ServantErr that looks as our errors should.
 -- Status code and reason phrase are taken from the base error given as first argument.
 -- The message given as second argument is wrapped into a 'ErrorMessage' JSON object.
-mkServantErr :: MkServantErrFun
+mkServantErr :: ServantErr -> ST -> ServantErr
 mkServantErr baseErr msg = baseErr
     {errBody = encode $ ErrorMessage msg, errHeaders = [contentTypeJsonHeader]}
+
+type ErrorInfo = (Maybe (Priority, String), ServantErr, ST)
 
 -- | Inspect an 'ActionError', log things, and construct a 'ServantErr'.
 --
@@ -97,70 +98,76 @@ mkServantErr baseErr msg = baseErr
 -- thrown.  The error constructors should take all the information in typed form.  Rendering
 -- (e.g. with 'show') and dispatching different parts of the information to differnet log levels and
 -- servant error is the sole responsibility of this function.
-actionErrorToServantErr :: ActionError -> IO ServantErr
-actionErrorToServantErr e = do
-    logger DEBUG $ ppShow e
+actionErrorToServantErr :: Show e
+                        => (e -> ErrorInfo) -> (ServantErr -> ST -> ServantErr)
+                        -> ActionError e -> IO ServantErr
+actionErrorToServantErr otherInfo mkServant e = do
+    let (l, se, m) = actionErrorInfo (thentosErrorInfo otherInfo) e
+    maybe (return ()) (uncurry logger) l
+    return $ mkServant se m
+
+baseActionErrorToServantErr :: ActionError () -> IO ServantErr
+baseActionErrorToServantErr = actionErrorToServantErr baseErrorInfo mkServantErr
+
+actionErrorInfo :: Show e => (ThentosError e -> ErrorInfo) -> ActionError e -> ErrorInfo
+actionErrorInfo thentosInfo e =
     case e of
-        (ActionErrorThentos  te) -> _thentos te
-        (ActionErrorAnyLabel le) -> _permissions le
-        (ActionErrorUnknown  _)  -> logger CRITICAL (ppShow e) >>
-                                    pure (mkServantErr err500 "internal error")
+        (ActionErrorThentos  te) -> thentosInfo te
+        (ActionErrorAnyLabel _)  -> (Just (DEBUG, ppShow e), err401, "unauthorized")
+        (ActionErrorUnknown  _)  -> (Just (CRITICAL, ppShow e), err500, "internal error")
+
+baseErrorInfo :: () -> (Maybe (Priority, String), ServantErr, ST)
+baseErrorInfo = const $
+    (Just (ERROR, "other error"), err500, "internal error")
+
+thentosErrorInfo :: Show e
+                 => (e -> ErrorInfo)
+                 -> ThentosError e
+                 -> ErrorInfo
+thentosErrorInfo other e = f e
   where
-    _thentos :: ThentosError -> IO ServantErr
-    _thentos te = case thentosErrorToServantErr Nothing te of
-        (Just (level, msg), se) -> logger level msg >> pure se
-        (Nothing,           se) ->                     pure se
-
-    _permissions :: AnyLabelError -> IO ServantErr
-    _permissions _ = logger DEBUG (ppShow e) >> pure (mkServantErr err401 "unauthorized")
-
-
-thentosErrorToServantErr :: Maybe MkServantErrFun -> ThentosError
-                         -> (Maybe (Priority, String), ServantErr)
-thentosErrorToServantErr mMkErr e = f e
-  where
-    mkErr = fromMaybe mkServantErr mMkErr
     f NoSuchUser =
-        (Nothing, mkErr err404 "user not found")
+        (Nothing, err404, "user not found")
     f NoSuchPendingUserConfirmation =
-        (Nothing, mkErr err400 "unconfirmed user not found")
+        (Nothing, err400, "unconfirmed user not found")
     f (MalformedConfirmationToken path) =
-        (Nothing, mkErr err400 $ "malformed confirmation token: " <> cs (show path))
+        (Nothing, err400, "malformed confirmation token: " <> cs (show path))
     f NoSuchService =
-        (Nothing, mkErr err400 "service not found")
+        (Nothing, err400, "service not found")
     f NoSuchThentosSession =
-        (Nothing, mkErr err400 "thentos session not found")
+        (Nothing, err400, "thentos session not found")
     f NoSuchServiceSession =
-        (Nothing, mkErr err400 "service session not found")
+        (Nothing, err400, "service session not found")
     f OperationNotPossibleInServiceSession =
-        (Nothing, mkErr err404 "operation not possible in service session")
+        (Nothing, err404, "operation not possible in service session")
     f ServiceAlreadyExists =
-        (Nothing, mkErr err403 "service already exists")
+        (Nothing, err403, "service already exists")
     f NotRegisteredWithService =
-        (Nothing, mkErr err403 "not registered with service")
+        (Nothing, err403, "not registered with service")
     f UserEmailAlreadyExists =
-        (Nothing, mkErr err403 "email already in use")
+        (Nothing, err403, "email already in use")
     f UserNameAlreadyExists =
-        (Nothing, mkErr err403 "user name already in use")
+        (Nothing, err403, "user name already in use")
     f UserIdAlreadyExists =    -- must be prevented earlier on
-        (Just (ERROR, ppShow e), mkErr err500 "internal error")
+        (Just (ERROR, ppShow e), err500, "internal error")
     f BadCredentials =
-        (Just (INFO, show e), mkErr err401 "unauthorized")
+        (Just (INFO, show e), err401, "unauthorized")
     f BadAuthenticationHeaders =
-        (Nothing, mkErr err400 "bad authentication headers")
+        (Nothing, err400, "bad authentication headers")
     f ProxyNotAvailable =
-        (Nothing, mkErr err404 "proxying not activated")
+        (Nothing, err404, "proxying not activated")
     f MissingServiceHeader =
-        (Nothing, mkErr err404 "headers do not contain service id")
+        (Nothing, err404, "headers do not contain service id")
     f (ProxyNotConfiguredForService sid) =
-        (Nothing, mkErr err404 $ "proxy not configured for service " <> cs (show sid))
+        (Nothing, err404, "proxy not configured for service " <> cs (show sid))
     f (NoSuchToken) =
-        (Nothing, mkErr err400 "no such token")
+        (Nothing, err400, "no such token")
     f (NeedUserA _ _) =
-        (Nothing, mkErr err404
+        (Nothing, err404,
             "thentos session belongs to service, cannot create service session")
     f (MalformedUserPath path) =
-        (Nothing, mkErr err400 $ "malformed user path: " <> cs (show path))
+        (Nothing, err400, "malformed user path: " <> cs (show path))
+    f (OtherError x) = other x
 
 
 -- * custom servers for servant

--- a/thentos-core/src/Thentos/Frontend.hs
+++ b/thentos-core/src/Thentos/Frontend.hs
@@ -27,7 +27,6 @@ import Thentos.Action.Core
 import Thentos.Config
 import Thentos.Frontend.Handlers.Combinators
 import Thentos.Frontend.Types
-import Thentos.Types
 
 
 runFrontend :: HttpConfig -> ActionState -> IO ()

--- a/thentos-core/src/Thentos/Frontend/Handlers.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers.hs
@@ -59,14 +59,14 @@ userRegister = do
                 blaze userRegisterRequestedPage
             Left e -> logger INFO (show e) >> crash 400 "Registration failed."
 
-sendUserConfirmationMail :: SmtpConfig -> UserFormData -> ST -> Action ()
+sendUserConfirmationMail :: SmtpConfig -> UserFormData -> ST -> Action () ()
 sendUserConfirmationMail smtpConfig user callbackUrl = do
     sendMail'P smtpConfig Nothing (udEmail user) subject message
   where
     message = "Please go to " <> callbackUrl <> " to confirm your account."
     subject = "Thentos account creation confirmation"
 
-sendUserExistsMail :: SmtpConfig -> UserEmail -> Action ()
+sendUserExistsMail :: SmtpConfig -> UserEmail -> Action () ()
 sendUserExistsMail smtpConfig address = do
     sendMail'P smtpConfig Nothing address subject message
   where
@@ -117,7 +117,7 @@ userLogin = do
 
 -- | If user name and password match, login.  Otherwise, redirect to
 -- login page with a message that asks to try again.
-userLoginCallAction :: Action (UserId, ThentosSessionToken) -> FH ()
+userLoginCallAction :: Action () (UserId, ThentosSessionToken) -> FH ()
 userLoginCallAction action = do
     eResult <- snapRunActionE action
       -- FIXME[mf]: See 'runThentosQueryWithLabel' in
@@ -159,7 +159,7 @@ resetPassword = do
             Left (ActionErrorThentos NoSuchUser) -> blaze resetPasswordRequestedPage
             Left e -> crash500 ("resetPassword" :: ST, e)
 
-sendPasswordResetMail :: SmtpConfig -> User -> ST -> Action ()
+sendPasswordResetMail :: SmtpConfig -> User -> ST -> Action () ()
 sendPasswordResetMail smtpConfig user callbackUrl = do
     sendMail'P smtpConfig Nothing (user ^. userEmail) subject message
   where
@@ -364,7 +364,7 @@ serviceLogin = do
         loggedIn :: FrontendSessionLoginData -> FH ()
         loggedIn fsl = do
             let tok = fsl ^. fslToken
-            eSessionToken :: Either ActionError ServiceSessionToken
+            eSessionToken :: Either (ActionError ()) ServiceSessionToken
                 <- snapRunActionE $ startServiceSession tok sid
 
             case eSessionToken of

--- a/thentos-core/src/Thentos/Frontend/Handlers/Combinators.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers/Combinators.hs
@@ -301,14 +301,14 @@ _tweakURI parse serialize tweak uriBS = either er ok $ parse laxURIParserOptions
 
 -- | Like 'snapRunActionE', but sends a snap error response in case of error rather than returning a
 -- left value.
-snapRunAction :: Action a -> FH a
+snapRunAction :: Action () a -> FH a
 snapRunAction = (>>= snapHandleAllErrors) . snapRunActionE
 
-snapRunAction'P :: Action a -> FH a
+snapRunAction'P :: Action () a -> FH a
 snapRunAction'P = (>>= snapHandleAllErrors) . snapRunActionE'P
 
 -- | Call 'snapHandleSomeErrors', and if error is still unhandled, call 'crash500'.
-snapHandleAllErrors :: Either ActionError a -> FH a
+snapHandleAllErrors :: Either (ActionError ()) a -> FH a
 snapHandleAllErrors eth = do
     result <- snapHandleSomeErrors eth
     case result of
@@ -323,7 +323,7 @@ getActionState = do
     return $ ActionState (db, rn, cf)
 
 -- | Run action with the clearance derived from thentos session token.
-snapRunActionE :: Action a -> FH (Either ActionError a)
+snapRunActionE :: Action () a -> FH (Either (ActionError ()) a)
 snapRunActionE action = do
     st :: ActionState         <- getActionState
     fs :: FrontendSessionData <- getSessionData
@@ -334,7 +334,7 @@ snapRunActionE action = do
     snapHandleSomeErrors result
 
 -- | Call action with top clearance.
-snapRunActionE'P :: Action a -> FH (Either ActionError a)
+snapRunActionE'P :: Action () a -> FH (Either (ActionError ()) a)
 snapRunActionE'P action = do
     st :: ActionState <- getActionState
     result <- liftIO $ runActionWithClearanceE dcTop st action
@@ -342,7 +342,7 @@ snapRunActionE'P action = do
 
 -- | This function handles particular error cases for the frontend and propagates others in 'Left'
 -- values.
-snapHandleSomeErrors :: Either ActionError a -> FH (Either ActionError a)
+snapHandleSomeErrors :: Either (ActionError ()) a -> FH (Either (ActionError ()) a)
 snapHandleSomeErrors (Right v) = return $ Right v
 snapHandleSomeErrors (Left e) = case e of
     ActionErrorAnyLabel labelError -> permissionDenied labelError

--- a/thentos-core/src/Thentos/Transaction/Transactions.hs
+++ b/thentos-core/src/Thentos/Transaction/Transactions.hs
@@ -20,45 +20,45 @@ import Thentos.Transaction.Core
 flattenGroups :: Service -> UserId -> [Group]
 flattenGroups = error "src/Thentos/Transaction/Transactions.hs:10"
 
-freshUserId :: ThentosQuery UserId
+freshUserId :: ThentosQuery e UserId
 freshUserId = error "src/Thentos/Transaction/Transactions.hs:13"
 
-assertUser :: Maybe UserId -> User -> ThentosQuery ()
+assertUser :: Maybe UserId -> User -> ThentosQuery e ()
 assertUser = error "src/Thentos/Transaction/Transactions.hs:16"
 
-assertUserIsNew :: User -> ThentosQuery ()
+assertUserIsNew :: User -> ThentosQuery e ()
 assertUserIsNew = error "src/Thentos/Transaction/Transactions.hs:19"
 
 type MatchUnconfirmedUserFun = ((UserId, User), Timestamp) -> Maybe UserId
 
-userNameExists :: Maybe UserId -> User -> ThentosQuery ()
+userNameExists :: Maybe UserId -> User -> ThentosQuery e ()
 userNameExists = error "src/Thentos/Transaction/Transactions.hs:24"
 
-userEmailExists :: Maybe UserId -> User -> ThentosQuery ()
+userEmailExists :: Maybe UserId -> User -> ThentosQuery e ()
 userEmailExists = error "src/Thentos/Transaction/Transactions.hs:27"
 
-userIdExists :: UserId -> ThentosQuery ()
+userIdExists :: UserId -> ThentosQuery e ()
 userIdExists = error "src/Thentos/Transaction/Transactions.hs:30"
 
 userFacetExists ::
-    ThentosError -> Maybe UserId -> MatchUnconfirmedUserFun -> Maybe UserId -> ThentosQuery ()
+    ThentosError e -> Maybe UserId -> MatchUnconfirmedUserFun -> Maybe UserId -> ThentosQuery e ()
 userFacetExists err mMatchingConfirmedUid unconfirmedUserMatches mUid = error "src/Thentos/Transaction/Transactions.hs:34"
 
-allUserIds :: ThentosQuery [UserId]
+allUserIds :: ThentosQuery e [UserId]
 allUserIds = error "src/Thentos/Transaction/Transactions.hs:37"
 
-lookupUser :: UserId -> ThentosQuery (UserId, User)
+lookupUser :: UserId -> ThentosQuery e (UserId, User)
 lookupUser uid = do
     users <- queryT [sql| SELECT name, password, email
                           FROM users
                           WHERE id = ? |] (Only uid)
     user <- case users of
-      []     -> throwError NoSuchUser
       [user] -> return user
-      _      -> error "lookupUser: multiple results"
+      []     -> throwError NoSuchUser
+      _      -> impossible "lookupUser: multiple results"
     return (uid, user)
 
-lookupUserByName :: UserName -> ThentosQuery (UserId, User)
+lookupUserByName :: UserName -> ThentosQuery e (UserId, User)
 lookupUserByName name = do
     users <- queryT [sql| SELECT id, name, password, email
                           FROM users
@@ -69,7 +69,7 @@ lookupUserByName name = do
       _                        -> impossible "lookupUserByName: multiple users"
 
 
-lookupUserByEmail :: UserEmail -> ThentosQuery (UserId, User)
+lookupUserByEmail :: UserEmail -> ThentosQuery e (UserId, User)
 lookupUserByEmail email = do
     users <- queryT [sql| SELECT id, name, password, email
                           FROM users
@@ -79,7 +79,7 @@ lookupUserByEmail email = do
       []                       -> throwError NoSuchUser
       _                        -> impossible "lookupUserByEmail: multiple users"
 
-addUserPrim :: UserId -> User -> ThentosQuery ()
+addUserPrim :: UserId -> User -> ThentosQuery e ()
 addUserPrim uid user = execT [sql| INSERT INTO users (id, name, password, email)
                                    VALUES (?, ?, ?, ?) |] ( uid
                                                           , user ^. userName
@@ -87,47 +87,47 @@ addUserPrim uid user = execT [sql| INSERT INTO users (id, name, password, email)
                                                           , user ^. userEmail
                                                           )
 
-addUser :: User -> ThentosQuery UserId
+addUser :: User -> ThentosQuery e UserId
 addUser = error "src/Thentos/Transaction/Transactions.hs:52"
 
-addUsers :: [User] -> ThentosQuery [UserId]
+addUsers :: [User] -> ThentosQuery e [UserId]
 addUsers = error "src/Thentos/Transaction/Transactions.hs:55"
 
 addUnconfirmedUser ::
-    Timestamp -> ConfirmationToken -> User -> ThentosQuery (UserId, ConfirmationToken)
+    Timestamp -> ConfirmationToken -> User -> ThentosQuery e (UserId, ConfirmationToken)
 addUnconfirmedUser = error "src/Thentos/Transaction/Transactions.hs:59"
 
 addUnconfirmedUserWithId ::
-    Timestamp -> ConfirmationToken -> User -> UserId -> ThentosQuery ConfirmationToken
+    Timestamp -> ConfirmationToken -> User -> UserId -> ThentosQuery e ConfirmationToken
 addUnconfirmedUserWithId = error "src/Thentos/Transaction/Transactions.hs:63"
 
 finishUserRegistration ::
-    Timestamp -> Timeout -> ConfirmationToken -> ThentosQuery UserId
+    Timestamp -> Timeout -> ConfirmationToken -> ThentosQuery e UserId
 finishUserRegistration = error "src/Thentos/Transaction/Transactions.hs:67"
 
 finishUserRegistrationById ::
-    Timestamp -> Timeout -> UserId -> ThentosQuery ()
+    Timestamp -> Timeout -> UserId -> ThentosQuery e ()
 finishUserRegistrationById = error "finishUserRegistrationById"
 
 addPasswordResetToken ::
-    Timestamp -> UserEmail -> PasswordResetToken -> ThentosQuery User
+    Timestamp -> UserEmail -> PasswordResetToken -> ThentosQuery e User
 addPasswordResetToken = error "src/Thentos/Transaction/Transactions.hs:71"
 
 resetPassword ::
-    Timestamp -> Timeout -> PasswordResetToken -> HashedSecret UserPass -> ThentosQuery ()
+    Timestamp -> Timeout -> PasswordResetToken -> HashedSecret UserPass -> ThentosQuery e ()
 resetPassword = error "src/Thentos/Transaction/Transactions.hs:75"
 
 addUserEmailChangeRequest :: Timestamp -> UserId -> UserEmail
                                              -> ConfirmationToken
-                                             -> ThentosQuery ()
+                                             -> ThentosQuery e ()
 addUserEmailChangeRequest = error "src/Thentos/Transaction/Transactions.hs:80"
 
 confirmUserEmailChange ::
-    Timestamp -> Timeout -> ConfirmationToken -> ThentosQuery UserId
+    Timestamp -> Timeout -> ConfirmationToken -> ThentosQuery e UserId
 confirmUserEmailChange = error "src/Thentos/Transaction/Transactions.hs:84"
 
 lookupEmailChangeToken ::
-    ConfirmationToken -> ThentosQuery ((UserId, UserEmail), Timestamp)
+    ConfirmationToken -> ThentosQuery e ((UserId, UserEmail), Timestamp)
 lookupEmailChangeToken = error "src/Thentos/Transaction/Transactions.hs:88"
 
 data UpdateUserFieldOp =
@@ -138,89 +138,89 @@ data UpdateUserFieldOp =
   | UpdateUserFieldPassword (HashedSecret UserPass)
   deriving (Eq)
 
-updateUserField :: UserId -> UpdateUserFieldOp -> ThentosQuery ()
+updateUserField :: UserId -> UpdateUserFieldOp -> ThentosQuery e ()
 updateUserField = error "src/Thentos/Transaction/Transactions.hs:99"
 
-updateUserFields :: UserId -> [UpdateUserFieldOp] -> ThentosQuery ()
+updateUserFields :: UserId -> [UpdateUserFieldOp] -> ThentosQuery e ()
 updateUserFields = error "src/Thentos/Transaction/Transactions.hs:102"
 
-deleteUser :: UserId -> ThentosQuery ()
+deleteUser :: UserId -> ThentosQuery e ()
 deleteUser = error "src/Thentos/Transaction/Transactions.hs:105"
 
-allServiceIds :: ThentosQuery [ServiceId]
+allServiceIds :: ThentosQuery e [ServiceId]
 allServiceIds = error "src/Thentos/Transaction/Transactions.hs:108"
 
-lookupService :: ServiceId -> ThentosQuery (ServiceId, Service)
+lookupService :: ServiceId -> ThentosQuery e (ServiceId, Service)
 lookupService = error "src/Thentos/Transaction/Transactions.hs:111"
 
 addService ::
     Agent -> ServiceId -> HashedSecret ServiceKey -> ServiceName
-    -> ServiceDescription -> ThentosQuery ()
+    -> ServiceDescription -> ThentosQuery e ()
 addService = error "src/Thentos/Transaction/Transactions.hs:116"
 
-deleteService :: ServiceId -> ThentosQuery ()
+deleteService :: ServiceId -> ThentosQuery e ()
 deleteService = error "src/Thentos/Transaction/Transactions.hs:119"
 
 lookupThentosSession ::
-    Timestamp -> ThentosSessionToken -> ThentosQuery (ThentosSessionToken, ThentosSession)
+    Timestamp -> ThentosSessionToken -> ThentosQuery e (ThentosSessionToken, ThentosSession)
 lookupThentosSession = error "src/Thentos/Transaction/Transactions.hs:123"
 
 startThentosSession :: ThentosSessionToken -> Agent -> Timestamp -> Timeout
-                                       -> ThentosQuery ()
+                                       -> ThentosQuery e ()
 startThentosSession = error "src/Thentos/Transaction/Transactions.hs:127"
 
-endThentosSession :: ThentosSessionToken -> ThentosQuery ()
+endThentosSession :: ThentosSessionToken -> ThentosQuery e ()
 endThentosSession = error "src/Thentos/Transaction/Transactions.hs:130"
 
 lookupServiceSession :: Timestamp -> ServiceSessionToken
-                                        -> ThentosQuery (ServiceSessionToken, ServiceSession)
+                                        -> ThentosQuery e (ServiceSessionToken, ServiceSession)
 lookupServiceSession = error "src/Thentos/Transaction/Transactions.hs:134"
 
 startServiceSession ::
     ThentosSessionToken -> ServiceSessionToken -> ServiceId
-    -> Timestamp -> Timeout -> ThentosQuery ()
+    -> Timestamp -> Timeout -> ThentosQuery e ()
 startServiceSession = error "src/Thentos/Transaction/Transactions.hs:139"
 
-endServiceSession :: ServiceSessionToken -> ThentosQuery ()
+endServiceSession :: ServiceSessionToken -> ThentosQuery e ()
 endServiceSession = error "src/Thentos/Transaction/Transactions.hs:142"
 
-assertAgent :: Agent -> ThentosQuery ()
+assertAgent :: Agent -> ThentosQuery e ()
 assertAgent = error "src/Thentos/Transaction/Transactions.hs:145"
 
-assignRole :: Agent -> Role -> ThentosQuery ()
+assignRole :: Agent -> Role -> ThentosQuery e ()
 assignRole = error "src/Thentos/Transaction/Transactions.hs:148"
 
-unassignRole :: Agent -> Role -> ThentosQuery ()
+unassignRole :: Agent -> Role -> ThentosQuery e ()
 unassignRole = error "src/Thentos/Transaction/Transactions.hs:151"
 
-agentRoles :: Agent -> ThentosQuery (Set.Set Role)
+agentRoles :: Agent -> ThentosQuery e (Set.Set Role)
 agentRoles = error "src/Thentos/Transaction/Transactions.hs:154"
 
-garbageCollectThentosSessions :: Timestamp -> ThentosQuery [ThentosSessionToken]
+garbageCollectThentosSessions :: Timestamp -> ThentosQuery e [ThentosSessionToken]
 garbageCollectThentosSessions = error "src/Thentos/Transaction/Transactions.hs:157"
 
 doGarbageCollectThentosSessions ::
-    [ThentosSessionToken] -> ThentosQuery ()
+    [ThentosSessionToken] -> ThentosQuery e ()
 doGarbageCollectThentosSessions = error "src/Thentos/Transaction/Transactions.hs:161"
 
 garbageCollectServiceSessions ::
-    Timestamp -> ThentosQuery [ServiceSessionToken]
+    Timestamp -> ThentosQuery e [ServiceSessionToken]
 garbageCollectServiceSessions = error "src/Thentos/Transaction/Transactions.hs:165"
 
 doGarbageCollectServiceSessions ::
-    [ServiceSessionToken] -> ThentosQuery ()
+    [ServiceSessionToken] -> ThentosQuery e ()
 doGarbageCollectServiceSessions = error "src/Thentos/Transaction/Transactions.hs:169"
 
 doGarbageCollectUnconfirmedUsers ::
-    Timestamp -> Timeout -> ThentosQuery ()
+    Timestamp -> Timeout -> ThentosQuery e ()
 doGarbageCollectUnconfirmedUsers = error "src/Thentos/Transaction/Transactions.hs:173"
 
 doGarbageCollectPasswordResetTokens ::
-    Timestamp -> Timeout -> ThentosQuery ()
+    Timestamp -> Timeout -> ThentosQuery e ()
 doGarbageCollectPasswordResetTokens = error "src/Thentos/Transaction/Transactions.hs:177"
 
 doGarbageCollectEmailChangeTokens ::
-    Timestamp -> Timeout -> ThentosQuery ()
+    Timestamp -> Timeout -> ThentosQuery e ()
 doGarbageCollectEmailChangeTokens = error "src/Thentos/Transaction/Transactions.hs:181"
 
 impossible :: String -> a

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -407,7 +407,7 @@ instance Show ProxyUri where
 
 -- * errors
 
-data ThentosError =
+data ThentosError e =
       NoSuchUser
     | NoSuchPendingUserConfirmation
     | MalformedConfirmationToken ST
@@ -428,10 +428,11 @@ data ThentosError =
     | NoSuchToken
     | NeedUserA ThentosSessionToken ServiceId
     | MalformedUserPath ST
+    | OtherError e
     deriving (Eq, Read, Show, Typeable)
 
 
-instance Exception ThentosError
+instance (Show e, Typeable e) => Exception (ThentosError e)
 
 
 -- * boilerplate

--- a/thentos-tests/src/Thentos/Test/Core.hs
+++ b/thentos-tests/src/Thentos/Test/Core.hs
@@ -86,14 +86,14 @@ testUsers = (\ (UserFormData name pass email) ->
 
 -- | Add a single test user (with fast scrypt params) from 'testUsers' to the database and return
 -- it.
-addTestUser :: Int -> Action (UserId, UserFormData, User)
+addTestUser :: Int -> Action () (UserId, UserFormData, User)
 addTestUser ((zip testUserForms testUsers !!) -> (uf, user)) = do
     uid <- update'P $ addUser user
     return (uid, uf, user)
 
 -- | Create a list of test users (with fast scrypt params), store them in the database, and return
 -- them for use in test cases.
-initializeTestUsers :: Action [(UserId, UserFormData, User)]
+initializeTestUsers :: Action () [(UserId, UserFormData, User)]
 initializeTestUsers = mapM addTestUser [0 .. length testUsers - 1]
 
 encryptTestSecret :: ByteString -> HashedSecret a
@@ -183,7 +183,7 @@ createActionState config = do
 
 loginAsGod :: ActionState -> IO (ThentosSessionToken, [Header])
 loginAsGod actionState = do
-    (_, tok :: ThentosSessionToken) <- runAction actionState $ startThentosSessionByUserName godName godPass
+    (_, tok) <- runAction actionState $ (startThentosSessionByUserName godName godPass :: Action () (UserId, ThentosSessionToken))
     let credentials :: [Header] = [(mk "X-Thentos-Session", cs $ fromThentosSessionToken tok)]
     return (tok, credentials)
 

--- a/thentos-tests/tests/Thentos/ActionSpec.hs
+++ b/thentos-tests/tests/Thentos/ActionSpec.hs
@@ -8,7 +8,7 @@ import Control.Applicative ((<$>))
 import Control.Lens ((.~), (^.))
 import Control.Monad (void)
 import Data.Either (isLeft, isRight)
-import LIO.DCLabel ((%%))
+import LIO.DCLabel (ToCNF, DCLabel, (%%))
 import Test.Hspec (Spec, SpecWith, describe, it, before, shouldBe, shouldContain,
                    shouldNotContain, shouldSatisfy, hspec)
 
@@ -44,113 +44,113 @@ spec_user = describe "user" $ do
     describe "addUser, lookupUser, deleteUser" $ do
         it "works" $ \ sta -> do
             let user = testUsers !! 0
-            uid <- runActionWithPrivs [RoleAdmin] sta $ addUser (head testUserForms)
-            (uid', user') <- runActionWithPrivs [RoleAdmin] sta $ lookupUser uid
+            uid <- runPrivs [RoleAdmin] sta $ addUser (head testUserForms)
+            (uid', user') <- runPrivs [RoleAdmin] sta $ lookupUser uid
             uid' `shouldBe` uid
             user' `shouldBe` (userPassword .~ (user' ^. userPassword) $ user)
-            void . runActionWithPrivs [RoleAdmin] sta $ deleteUser uid
+            void . runPrivs [RoleAdmin] sta $ deleteUser uid
             Left (ActionErrorThentos NoSuchUser) <-
-                runActionWithClearanceE dcBottom sta $ lookupUser uid
+                runClearanceE dcBottom sta $ lookupUser uid
             return ()
 
         it "guarantee that user names are unique" $ \ sta -> do
-            (_, _, user) <- runActionWithClearance dcBottom sta $ addTestUser 1
+            (_, _, user) <- runClearance dcBottom sta $ addTestUser 1
             let userFormData = UserFormData (user ^. userName)
                                             (UserPass "foo")
                                             (forceUserEmail "new@one.com")
-            Left (ActionErrorThentos e) <- runActionWithPrivsE [RoleAdmin] sta $
+            Left (ActionErrorThentos e) <- runPrivsE [RoleAdmin] sta $
                 addUser userFormData
             e `shouldBe` UserNameAlreadyExists
 
         it "guarantee that user email addresses are unique" $ \ sta -> do
-            (_, _, user) <- runActionWithClearance dcBottom sta $ addTestUser 1
+            (_, _, user) <- runClearance dcBottom sta $ addTestUser 1
             let userFormData = UserFormData (UserName "newOne")
                                             (UserPass "foo")
                                             (user ^. userEmail)
-            Left (ActionErrorThentos e) <- runActionWithPrivsE [RoleAdmin] sta $ addUser userFormData
+            Left (ActionErrorThentos e) <- runPrivsE [RoleAdmin] sta $ addUser userFormData
             e `shouldBe` UserEmailAlreadyExists
 
 
     describe "addUsers" $ do
         it "works" $ \ sta -> do
-            result <- runActionWithPrivs [RoleAdmin] sta $
+            result <- runPrivs [RoleAdmin] sta $
                 addUsers ((testUserForms !!) <$> [2..4])
             result `shouldBe` (UserId <$> [1..3])
 
         it "rolls back in case of error (adds all or nothing)" $ \ sta -> do
-            _ <- runActionWithPrivs [RoleAdmin] sta $ addUser (testUserForms !! 4)
-            Left (ActionErrorThentos e) <- runActionWithPrivsE [RoleAdmin] sta
+            _ <- runPrivs [RoleAdmin] sta $ addUser (testUserForms !! 4)
+            Left (ActionErrorThentos e) <- runPrivsE [RoleAdmin] sta
                 $ addUsers ((testUserForms !!) <$> [2..4])
             e `shouldBe` UserNameAlreadyExists
-            result <- runActionWithPrivs [RoleAdmin] sta allUserIds
+            result <- runPrivs [RoleAdmin] sta allUserIds
             result `shouldBe` (UserId <$> [0..1])
 
     describe "DeleteUser" $ do
         it "user can delete herself, even if not admin" $ \ sta -> do
-            (uid, _, _) <- runActionWithClearance dcBottom sta $ addTestUser 3
-            result <- runActionWithPrivsE [UserA uid] sta $ deleteUser uid
+            (uid, _, _) <- runClearance dcBottom sta $ addTestUser 3
+            result <- runPrivsE [UserA uid] sta $ deleteUser uid
             result `shouldSatisfy` isRight
 
         it "nobody else but the deleted user and admin can do this" $ \ sta -> do
-            (uid,  _, _) <- runActionWithClearance dcBottom sta $ addTestUser 3
-            (uid', _, _) <- runActionWithClearance dcBottom sta $ addTestUser 4
-            result <- runActionWithPrivsE [UserA uid] sta $ deleteUser uid'
+            (uid,  _, _) <- runClearance dcBottom sta $ addTestUser 3
+            (uid', _, _) <- runClearance dcBottom sta $ addTestUser 4
+            result <- runPrivsE [UserA uid] sta $ deleteUser uid'
             result `shouldSatisfy` isLeft
 
     describe "UpdateUser" $ do
         it "changes user if it exists" $ \ sta -> do
-            (uid, _, user) <- runActionWithClearance dcBottom sta $ addTestUser 1
-            runActionWithPrivs [UserA uid] sta $
+            (uid, _, user) <- runClearance dcBottom sta $ addTestUser 1
+            runPrivs [UserA uid] sta $
                 updateUserField uid (UpdateUserFieldName "fka_user1")
 
-            result <- runActionWithPrivs [UserA uid] sta $ lookupUser uid
+            result <- runPrivs [UserA uid] sta $ lookupUser uid
             result `shouldBe` (UserId 1, userName .~ "fka_user1" $ user)
 
         it "throws an error if user does not exist" $ \ sta -> do
-            Left (ActionErrorThentos e) <- runActionWithPrivsE [RoleAdmin] sta $
+            Left (ActionErrorThentos e) <- runPrivsE [RoleAdmin] sta $
                 updateUserField (UserId 391) (UpdateUserFieldName "moo")
             e `shouldBe` NoSuchUser
 
     describe "checkPassword" $ do
         it "works" $ \ sta -> do
-            void . runAction sta $ startThentosSessionByUserId godUid godPass
-            void . runAction sta $ startThentosSessionByUserName godName godPass
+            void . runA sta $ startThentosSessionByUserId godUid godPass
+            void . runA sta $ startThentosSessionByUserName godName godPass
 
 
 spec_service :: SpecWith ActionState
 spec_service = describe "service" $ do
     describe "addService, lookupService, deleteService" $ do
         it "works" $ \ sta -> do
-            let addsvc name desc = runActionWithClearanceE (UserA godUid %% UserA godUid) sta
+            let addsvc name desc = runClearanceE (UserA godUid %% UserA godUid) sta
                     $ addService (UserA (UserId 0)) name desc
             Right (service1_id, _s1_key) <- addsvc "fake name" "fake description"
             Right (service2_id, _s2_key) <- addsvc "different name" "different description"
-            service1 <- runActionWithPrivs [RoleAdmin] sta $ lookupService service1_id
-            service2 <- runActionWithPrivs [RoleAdmin] sta $ lookupService service2_id
+            service1 <- runPrivs [RoleAdmin] sta $ lookupService service1_id
+            service2 <- runPrivs [RoleAdmin] sta $ lookupService service2_id
             service1 `shouldBe` service1 -- sanity check for reflexivity of Eq
             service1 `shouldSatisfy` (/= service2) -- should have different keys
-            void . runActionWithPrivs [RoleAdmin] sta $ deleteService service1_id
+            void . runPrivs [RoleAdmin] sta $ deleteService service1_id
             Left (ActionErrorThentos NoSuchService) <-
-                runActionWithPrivsE [RoleAdmin] sta $ lookupService service1_id
+                runPrivsE [RoleAdmin] sta $ lookupService service1_id
             return ()
 
     describe "autocreateServiceIfMissing" $ do
         it "adds service if missing" $ \ sta -> do
             let owner = UserA $ UserId 0
-            sid <- runActionWithPrivs [RoleAdmin] sta $ freshServiceId
-            allSids <- runActionWithPrivs [RoleAdmin] sta allServiceIds
+            sid <- runPrivs [RoleAdmin] sta $ freshServiceId
+            allSids <- runPrivs [RoleAdmin] sta allServiceIds
             allSids `shouldNotContain` [sid]
-            runActionWithPrivs [RoleAdmin] sta $ autocreateServiceIfMissing'P owner sid
-            allSids' <- runActionWithPrivs [RoleAdmin] sta allServiceIds
+            runPrivs [RoleAdmin] sta $ autocreateServiceIfMissing'P owner sid
+            allSids' <- runPrivs [RoleAdmin] sta allServiceIds
             allSids' `shouldContain` [sid]
 
         it "does nothing if service exists" $ \ sta -> do
             let owner = UserA $ UserId 0
-            (sid, _) <- runActionWithPrivs [RoleAdmin] sta
+            (sid, _) <- runPrivs [RoleAdmin] sta
                             $ addService owner "fake name" "fake description"
-            allSids <- runActionWithPrivs [RoleAdmin] sta allServiceIds
-            runActionWithPrivs [RoleAdmin] sta $ autocreateServiceIfMissing'P owner sid
-            allSids' <- runActionWithPrivs [RoleAdmin] sta allServiceIds
+            allSids <- runPrivs [RoleAdmin] sta allServiceIds
+            runPrivs [RoleAdmin] sta $ autocreateServiceIfMissing'P owner sid
+            allSids' <- runPrivs [RoleAdmin] sta allServiceIds
             allSids `shouldBe` allSids'
 
 spec_agentsAndRoles :: SpecWith ActionState
@@ -158,30 +158,30 @@ spec_agentsAndRoles = describe "agentsAndRoles" $ do
     describe "agents and roles" $ do
         describe "assign" $ do
             it "can be called by admins" $ \ sta -> do
-                (UserA -> targetAgent, _, _) <- runActionWithClearance dcBottom sta $ addTestUser 1
-                result <- runActionWithPrivsE [RoleAdmin] sta $ assignRole targetAgent (RoleBasic RoleAdmin)
+                (UserA -> targetAgent, _, _) <- runClearance dcBottom sta $ addTestUser 1
+                result <- runPrivsE [RoleAdmin] sta $ assignRole targetAgent (RoleBasic RoleAdmin)
                 result `shouldSatisfy` isRight
 
             it "can NOT be called by any non-admin agents" $ \ sta -> do
                 let targetAgent = UserA $ UserId 1
-                result <- runActionWithPrivsE [targetAgent] sta $ assignRole targetAgent (RoleBasic RoleAdmin)
+                result <- runPrivsE [targetAgent] sta $ assignRole targetAgent (RoleBasic RoleAdmin)
                 result `shouldSatisfy` isLeft
 
         describe "lookup" $ do
             it "can be called by admins" $ \ sta -> do
                 let targetAgent = UserA $ UserId 1
-                result <- runActionWithPrivsE [RoleAdmin] sta $ agentRoles targetAgent
+                result <- runPrivsE [RoleAdmin] sta $ agentRoles targetAgent
                 result `shouldSatisfy` isRight
 
             it "can be called by user for her own roles" $ \ sta -> do
                 let targetAgent = UserA $ UserId 1
-                result <- runActionWithPrivsE [targetAgent] sta $ agentRoles targetAgent
+                result <- runPrivsE [targetAgent] sta $ agentRoles targetAgent
                 result `shouldSatisfy` isRight
 
             it "can NOT be called by other users" $ \ sta -> do
                 let targetAgent = UserA $ UserId 1
                     askingAgent = UserA $ UserId 2
-                result <- runActionWithPrivsE [askingAgent] sta $ agentRoles targetAgent
+                result <- runPrivsE [askingAgent] sta $ agentRoles targetAgent
                 result `shouldSatisfy` isLeft
 
 
@@ -189,22 +189,45 @@ spec_session :: SpecWith ActionState
 spec_session = describe "session" $ do
     describe "StartSession" $ do
         it "works" $ \ sta -> do
-            result <- runActionE sta $ startThentosSessionByUserName godName godPass
+            result <- runAE sta $ startThentosSessionByUserName godName godPass
             result `shouldSatisfy` isRight
             return ()
 
     describe "lookupThentosSession" $ do
         it "works" $ \ sta -> do
             ((ernieId, ernieF, _) : (bertId, _, _) : _)
-                <- runActionWithClearance dcTop sta initializeTestUsers
+                <- runClearance dcTop sta initializeTestUsers
 
-            tok <- runActionWithClearance dcTop sta $
+            tok <- runClearance dcTop sta $
                     startThentosSessionByUserId ernieId (udPassword ernieF)
-            v1 <- runActionAsAgent (UserA ernieId) sta (existsThentosSession tok)
-            v2 <- runActionAsAgent (UserA bertId)  sta (existsThentosSession tok)
+            v1 <- runAsAgent (UserA ernieId) sta (existsThentosSession tok)
+            v2 <- runAsAgent (UserA bertId)  sta (existsThentosSession tok)
 
-            runActionWithClearance dcTop sta $ endThentosSession tok
-            v3 <- runActionAsAgent (UserA ernieId) sta (existsThentosSession tok)
-            v4 <- runActionAsAgent (UserA bertId)  sta (existsThentosSession tok)
+            runClearance dcTop sta $ endThentosSession tok
+            v3 <- runAsAgent (UserA ernieId) sta (existsThentosSession tok)
+            v4 <- runAsAgent (UserA bertId)  sta (existsThentosSession tok)
 
             (v1, v2, v3, v4) `shouldBe` (True, False, False, False)
+
+-- specialize to error type ()
+runA :: ActionState -> Action () a -> IO a
+runA = runAction
+
+runAE :: ActionState -> Action () a -> IO (Either (ActionError ()) a)
+runAE = runActionE
+
+runAsAgent :: Agent -> ActionState -> Action () a -> IO a
+runAsAgent = runActionAsAgent
+
+runPrivs :: ToCNF cnf => [cnf] -> ActionState -> Action () a -> IO a
+runPrivs = runPrivs
+
+runPrivsE :: ToCNF cnf => [cnf] -> ActionState -> Action () a -> IO (Either (ActionError ()) a)
+runPrivsE = runPrivsE
+
+runClearanceE :: DCLabel -> ActionState -> Action () a -> IO (Either (ActionError ()) a)
+runClearanceE = runActionWithClearanceE
+
+runClearance :: DCLabel -> ActionState -> Action () a -> IO a
+runClearance = runActionWithClearance
+

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -80,7 +80,7 @@ spec_createUser = describe "create user" $ do
             WD.getSource >>= \s -> liftIO $ s `shouldSatisfy` ST.isInfixOf "Please check your email"
 
         -- check that user is in db
-        eUser <- runThentosQuery st $ T.lookupUserByName (UserName myUsername)
+        (eUser :: Either (ThentosError ()) (UserId, User)) <- runThentosQuery st $ T.lookupUserByName (UserName myUsername)
         fromUserName  . (^. userName)  . snd <$> eUser `shouldBe` Right myUsername
         fromUserEmail . (^. userEmail) . snd <$> eUser `shouldBe` Right myEmail
 

--- a/thentos-tests/thentos-tests.cabal
+++ b/thentos-tests/thentos-tests.cabal
@@ -131,6 +131,7 @@ test-suite tests
     , mime-mail
     , mtl
     , network
+    , postgresql-simple
     , pretty-show
     , process
     , QuickCheck


### PR DESCRIPTION
This puts some flexibility back into the errors, which got lost when DB extension was removed. Also tries to clean up the conversion to servant errors a bit. Something like this will be needed to get thentos-adhocracy to work with postgres.

I'm not entirely convinced this is the best way to go. Problems:
* `ThentosError ()` now has a bogus error `OtherError ()`
* need `(Show e, Typeable e)` contexts all over the place
* need to add type signatures to specialize actions to `Action () a` from `Action e a`, particularly in tests; compare the the runAction mess in ActionSpec.hs

The alternative approach that I see is to have

```
-- no ThentosError in here
newtype Action e a = Action (ReaderT ActionState (EitherT e (LIO DCLabel)) a)

type ThentosAction = Action ThentosError
```
then define all transactions/actions in thentos-core as ThentosAction and friends.

In thentos-adhocracy, define `ThentosA3Error` as before to extend `ThentosError`, and "lift" actions via
```
Action ThentosError a -> Action ThentosA3Error a
```

