### PR TITLE
Re-add disabled test for activate_account error handling

### DIFF
--- a/thentos-tests/src/Thentos/Test/Network.hs
+++ b/thentos-tests/src/Thentos/Test/Network.hs
@@ -3,7 +3,7 @@
 module Thentos.Test.Network
 where
 
-import Control.Concurrent.Async (Async, async, cancel, wait, link)
+import Control.Concurrent.Async (Async, async, cancel, wait)
 import Control.Exception (catch, AsyncException(ThreadKilled))
 import Data.Maybe (fromMaybe)
 import Data.String.Conversions (LBS, SBS)


### PR DESCRIPTION
This re-adds an activate_account test that got disabled after it required the A3 backend to run. The backend is now faked.

This is a partial fix for #239. However, I left the bigger task of re-testing the user creation process, because the old test relies on the acidstate DB. Since acidstate will soon disappear, it makes more sense to fix that test after our switch to SQL is complete.