### PR TITLE
stop fake a3 backend even on test failure

### DIFF
--- a/thentos-tests/src/Thentos/Test/Network.hs
+++ b/thentos-tests/src/Thentos/Test/Network.hs
@@ -3,7 +3,7 @@
 module Thentos.Test.Network
 where
 
-import Control.Concurrent.Async (Async, async, cancel, wait, link)
+import Control.Concurrent.Async (Async, async, cancel, wait)
 import Control.Exception (catch, AsyncException(ThreadKilled))
 import Data.Maybe (fromMaybe)
 import Data.String.Conversions (LBS, SBS)

--- a/thentos-tests/src/Thentos/Test/Network.hs
+++ b/thentos-tests/src/Thentos/Test/Network.hs
@@ -27,7 +27,6 @@ openTestSocket = do
 startDaemon :: IO () -> IO (Async ())
 startDaemon x = do
     a <- async x
-    link a
     return a
 
 -- | Stop a background processes.


### PR DESCRIPTION
I'm not really sure this is the best way to do things, but it's the only way I could figure out.

Somehow, it's wrong to take the a3 message out of the test `it`, but `around` and friends only work on that level. An alternative might be to run `bracket` inside the `it`, but that's tricky with the `WaiSession`.