### PR TITLE
reverting the extra source files in cabal attempt to fix test dependency tracking

### DIFF
--- a/misc/hspec-depend.sh
+++ b/misc/hspec-depend.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# This generates an extra-source-files entry for a cabal file in
-# the current directory, to fix dependency tracking when using
-# hspec-discover.
-
-echo extra-source-files:
-find . -type f | grep -E '[a-zA-Z0-9]Spec\.l?hs' | sed -e 's/^../  /'

--- a/thentos-adhocracy/thentos-adhocracy.cabal
+++ b/thentos-adhocracy/thentos-adhocracy.cabal
@@ -13,10 +13,6 @@ category:            Authentication
 build-type:          Simple
 cabal-version:       >= 1.18
 
-extra-source-files:
-  tests/Thentos/Adhocracy3/Backend/Api/ProxySpec.hs
-  tests/Thentos/Adhocracy3/Backend/Api/SimpleSpec.hs
-
 Source-Repository head
   type: git
   location: https://github.com/liqd/thentos

--- a/thentos-tests/thentos-tests.cabal
+++ b/thentos-tests/thentos-tests.cabal
@@ -13,14 +13,6 @@ category:            Authentication
 build-type:          Simple
 cabal-version:       >= 1.18
 
-extra-source-files:
-  tests/Thentos/ActionSpec.hs
-  tests/Thentos/Backend/Api/SimpleSpec.hs
-  tests/Thentos/FrontendSpec.hs
-  tests/Thentos/TypesSpec.hs
-  tests/Thentos/TransactionSpec.hs
-  tests/ThentosSpec.hs
-
 Source-Repository head
   type: git
   location: https://github.com/liqd/thentos


### PR DESCRIPTION
It doesn't work (anymore? seems to me like since I upgraded stack).