### PR TITLE
Lower cryptonite version bounds to make stack happy

### DIFF
--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -95,7 +95,7 @@ library
     , case-insensitive >=1.2.0.4 && <1.3
     , configifier >=0.0.5 && <0.1
     , containers >=0.5.6.2 && <0.6
-    , cryptonite >=0.7 && <0.8
+    , cryptonite >=0.6 && <0.7
     , digestive-functors >=0.8.0.0 && <0.9
     , digestive-functors-blaze >=0.6.0.6 && <0.7
     , digestive-functors-snap >=0.6.1.3 && <0.7

--- a/thentos-tests/thentos-tests.cabal
+++ b/thentos-tests/thentos-tests.cabal
@@ -50,7 +50,7 @@ library
     , case-insensitive >=1.2.0.4 && <1.3
     , configifier >=0.0.5 && <0.1
     , containers >=0.5.6.2 && <0.6
-    , cryptonite >=0.7 && <0.8
+    , cryptonite >=0.6 && <0.7
     , filepath >=1.4.0.0 && <1.5
     , hslogger >=1.2.9 && <1.3
     , http-types >=0.8.6 && <0.9


### PR DESCRIPTION
Current stackage only has cryptonite 0.6, so `stack build` fails with the current bounds.