### PR TITLE
Two refactorings to make transaction testing more convenient

### DIFF
--- a/thentos-tests/src/Thentos/Test/Transaction.hs
+++ b/thentos-tests/src/Thentos/Test/Transaction.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImplicitParams    #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Thentos.Test.Transaction where
@@ -8,18 +9,19 @@ import Data.Void (Void)
 import Data.String.Conversions (SBS)
 import Database.PostgreSQL.Simple (Connection, FromRow, ToRow, Only(..), query, query_)
 import Database.PostgreSQL.Simple.Types (Query(..))
+import GHC.Stack (CallStack)
 import Test.Hspec (shouldBe)
 
 import Thentos.Transaction.Core
 import Thentos.Types
 
 -- | Like 'runThentosQuery', but take connection from pool.
-runThentosQueryFromPool :: Pool Connection -> ThentosQuery e a -> IO (Either (ThentosError e) a)
-runThentosQueryFromPool connPool q = withResource connPool $ \conn -> runThentosQuery conn q
+runPooledQuery :: Pool Connection -> ThentosQuery e a -> IO (Either (ThentosError e) a)
+runPooledQuery connPool q = withResource connPool $ \conn -> runThentosQuery conn q
 
--- | Like 'runThentosQueryFromPool', but specialize error type to Void.
-runQuery :: Pool Connection -> ThentosQuery Void a -> IO (Either (ThentosError Void) a)
-runQuery = runThentosQueryFromPool
+-- | Like 'runPooledQuery', but specialize error type to Void.
+runVoidedQuery :: Pool Connection -> ThentosQuery Void a -> IO (Either (ThentosError Void) a)
+runVoidedQuery = runPooledQuery
 
 -- | Take a connection from the pool and execute the query.
 doQuery :: (ToRow q, FromRow r) => Pool Connection -> Query -> q -> IO [r]
@@ -30,7 +32,7 @@ doQuery_ connPool stmt = withResource connPool $ \conn -> query_ conn stmt
 
 -- | Check that a database table contains the expected number of rows.
 -- DON'T use this in production case, it's totally unprotected against SQL injection!
-rowCountShouldBe :: Pool Connection -> SBS -> Int -> IO ()
+rowCountShouldBe :: (?loc :: CallStack) => Pool Connection -> SBS -> Int -> IO ()
 rowCountShouldBe connPool table count = do
     [Only actualCount] <- doQuery_ connPool . Query $ "SELECT COUNT(*) FROM " <> table
     actualCount `shouldBe` count


### PR DESCRIPTION
* The helper functions for running ThentosQuery's from a pool have been
  renamed for clarity
* rowCountShouldBe (introduced yesterday) now reports as error location the
  place where it was called rather than its own implementation