### PR TITLE
Thentos frontend state monad based on servant-session.

### DIFF
--- a/thentos-core/src/Thentos/Backend/Core.hs
+++ b/thentos-core/src/Thentos/Backend/Core.hs
@@ -70,11 +70,11 @@ enterAction state toServantErr mTok = Nat $ ExceptT . run toServantErr
     run :: (Show e, Typeable e)
         => (ActionError e -> IO ServantErr)
         -> Action e a -> IO (Either ServantErr a)
-    run e = (>>= fmapLM e) . runActionE state . updatePrivs mTok
+    run e = (>>= fmapLM e) . runActionE state . (updatePrivs mTok >>)
 
-    updatePrivs :: Maybe ThentosSessionToken -> Action e a -> Action e a
-    updatePrivs (Just tok) action = (accessRightsByThentosSession'P tok >>= grantAccessRights'P) >> action
-    updatePrivs Nothing    action = action
+    updatePrivs :: Maybe ThentosSessionToken -> Action e ()
+    updatePrivs (Just tok) = accessRightsByThentosSession'P tok >>= grantAccessRights'P
+    updatePrivs Nothing    = return ()
 
 
 -- * error handling

--- a/thentos-core/src/Thentos/Frontend/State.hs
+++ b/thentos-core/src/Thentos/Frontend/State.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+
+module Thentos.Frontend.State where
+
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except (ExceptT(ExceptT))
+import Control.Monad.Trans.State (StateT, runStateT, get, gets, put)
+import Data.Char (ord)
+import Data.Functor.Infix ((<$$>))
+import Data.String.Conversions (SBS)
+import Data.Void (Void)
+import LIO (liftLIO)
+import LIO.TCB (ioTCB)
+import Network.Wai (Middleware, Application)
+import Network.Wai.Session (SessionStore, Session, withSession)
+import Servant (Proxy(Proxy), ServantErr, (:>), serve, HasServer, ServerT, Server)
+import Servant.Server.Internal.Enter ((:~>)(Nat), Enter, enter)
+import Servant.Session (SSession)
+import Web.Cookie (SetCookie, def, setCookieName)
+
+import qualified Data.ByteString as SBS
+import qualified Data.Vault.Lazy as Vault
+import qualified Network.Wai.Session.Map as SessionMap
+
+import Thentos.Types (ThentosSessionToken)
+import Thentos.Util
+import Thentos.Action.Core
+import Thentos.Backend.Core (baseActionErrorToServantErr)
+import Thentos.Frontend.Types
+
+
+-- * types
+
+type FAction = StateT FrontendSessionData (Action Void)
+
+-- FIXME: where do we put frontend errors?  and where backend errors?  how do we handle them?
+
+runFActionE :: FrontendSessionData -> ActionState -> FAction a
+            -> IO (Either (ActionError Void) (a, FrontendSessionData))
+runFActionE fState aState fServer = runActionE aState $ runStateT fServer fState
+
+
+type FSession        = Session IO () FrontendSessionData
+type FSessionMap     = Vault.Key FSession -> Maybe FSession
+type FSessionStore   = SessionStore IO () FrontendSessionData
+type FServantSession = SSession IO () FrontendSessionData
+
+
+-- * middleware
+
+setCookie :: SetCookie
+setCookie = def { setCookieName = "thentos" }  -- FIXME: make 'SetCookie' configurable with configifier.
+
+cookieName :: SBS
+cookieName = let n = setCookieName setCookie in
+    if cookieNameValid n
+        then n
+        else error $ "Thentos.Frontend.State: bad cookie name: " ++ show n
+
+cookieNameValid :: SBS -> Bool
+cookieNameValid = SBS.all (`elem` (fromIntegral . ord <$> '_':['a'..'z']))
+
+thentosSessionMiddleware :: IO (Middleware, Vault.Key FSession)
+thentosSessionMiddleware = do
+    smap :: FSessionStore <- SessionMap.mapStore_
+    key  :: Vault.Key FSession <- Vault.newKey
+    return (withSession smap cookieName setCookie key, key)
+
+
+-- * frontend action monad
+
+serveFAction :: forall api.
+        ( HasServer api
+        , Enter (ServerT api FAction) (FAction :~> ExceptT ServantErr IO) (Server api)
+        )
+     => Proxy api -> ServerT api FAction -> ActionState -> IO Application
+serveFAction _ fServer aState = thentosSessionMiddleware >>= \(mw, key) -> return (mw $ app key)
+  where
+    app :: Vault.Key FSession -> Application
+    app key = serve (Proxy :: Proxy (FServantSession :> api)) (server' key)
+
+    server' :: Vault.Key FSession -> FSessionMap -> Server api
+    server' key smap = enter nt fServer
+      where
+        nt :: FAction :~> ExceptT ServantErr IO
+        nt = enterFAction aState baseActionErrorToServantErr key smap
+
+
+enterFAction ::
+       ActionState
+    -> (ActionError Void -> IO ServantErr)
+    -> Vault.Key FSession
+    -> FSessionMap
+    -> FAction :~> ExceptT ServantErr IO
+enterFAction aState toServantErr key smap = Nat $ ExceptT . (>>= fmapLM toServantErr) . run
+  where
+    run :: forall a. FAction a -> IO (Either (ActionError Void) a)
+    run fServer = fst <$$> runFActionE emptyFrontendSessionData aState fServer'
+      where
+        fServer' :: FAction a
+        fServer' = do
+            case smap key of
+                Nothing -> error $ "enterFAction: internal error in servant-session: no cookie!"
+                Just (lkup, ins) -> do
+                    cookieToFSession (lkup ())
+                    updatePrivs
+                    a <- fServer
+                    cookieFromFSession (ins ())
+                    return a
+
+    updatePrivs :: FAction ()
+    updatePrivs = gets l >>= lift . updatePrivs'
+      where
+        l :: FrontendSessionData -> Maybe ThentosSessionToken
+        l (FrontendSessionData (Just (FrontendSessionLoginData t _)) _ _) = Just t
+        l _ = Nothing
+
+    updatePrivs' :: Maybe ThentosSessionToken -> Action e ()
+    updatePrivs' (Just tok) = accessRightsByThentosSession'P tok >>= grantAccessRights'P
+    updatePrivs' Nothing    = return ()
+
+
+-- | Write 'FrontendSessionData' from the servant-session state to 'FAction' state.  If there is no
+-- state, do nothing.
+cookieToFSession :: IO (Maybe FrontendSessionData) -> FAction ()
+cookieToFSession r = (lift . liftLIO . ioTCB) r >>= maybe (return ()) put
+
+-- | Read 'FrontendSessionData' from 'FAction' and write back into servant-session state.
+cookieFromFSession :: (FrontendSessionData -> IO ()) -> FAction ()
+cookieFromFSession w = get >>= lift . liftLIO . ioTCB . w

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -77,6 +77,7 @@ library
     , Thentos.Frontend.Handlers
     , Thentos.Frontend.Handlers.Combinators
     , Thentos.Frontend.Pages
+    , Thentos.Frontend.State
     , Thentos.Frontend.Types
     , Thentos.Smtp
     , Thentos.Transaction
@@ -103,6 +104,7 @@ library
     , cond >=0.4 && <0.5
     , configifier >=0.0.6 && <0.1
     , containers >=0.5.6.2 && <0.6
+    , cookie >=0.4.1 && <0.5
     , cryptonite >=0.6 && <0.7
     , digestive-functors >=0.8.0.0 && <0.9
     , digestive-functors-blaze >=0.6.0.6 && <0.7
@@ -150,9 +152,11 @@ library
     , transformers >=0.4.2.0 && <0.5
     , unordered-containers >=0.2.5.1 && <0.3
     , uri-bytestring >=0.1.8 && <0.2
+    , vault >=0.3 && <0.4
     , wai >=3.0.3.0 && <3.1
     , wai-digestive-functors
     , wai-extra >= 3.0 && <3.1
+    , wai-session >=0.3.2 && <0.4
     , warp >=3.1.3 && <3.2
     , x509 ==1.6.1
     , x509-validation ==1.6.2

--- a/thentos-tests/tests/Thentos/Frontend/StateSpec.hs
+++ b/thentos-tests/tests/Thentos/Frontend/StateSpec.hs
@@ -48,11 +48,6 @@ spec_frontendState = do
         liftIO $ simpleBody gresp2 `shouldBe`
             (cs . show . fmap show $ [FrontendMsgSuccess "ping", FrontendMsgSuccess "heya"])
 
-{-
-    it "something about exceptions..." $ do
-        pending
--}
-
 
 getCookie :: SResponse -> RequestHeaders
 getCookie = fmap f . simpleHeaders

--- a/thentos-tests/tests/Thentos/Frontend/StateSpec.hs
+++ b/thentos-tests/tests/Thentos/Frontend/StateSpec.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE TypeOperators        #-}
+
+{-# OPTIONS -fno-warn-incomplete-patterns #-}
+
+module Thentos.Frontend.StateSpec where
+
+import Control.Lens ((^.), (%~))
+import Control.Monad.State (modify, gets, liftIO)
+import Data.String.Conversions (ST, cs)
+import Network.HTTP.Types (RequestHeaders, methodGet, methodPost)
+import Network.Wai (Application)
+import Network.Wai.Test (simpleBody, simpleHeaders, SResponse)
+import Servant (Proxy(Proxy), ServerT, Capture, Post, Get, JSON, (:<|>)((:<|>)), (:>))
+import Test.Hspec (Spec, SpecWith, hspec, before, describe, it, shouldBe)
+import Test.Hspec.Wai (request)
+
+import Thentos.Frontend.State
+import Thentos.Frontend.Types
+import Thentos.Test.Config
+import Thentos.Test.Core
+
+
+tests :: IO ()
+tests = hspec spec
+
+spec :: Spec
+spec = describe "Thentos.Frontend.State" . before testApp $ do
+    spec_frontendState
+
+spec_frontendState :: SpecWith Application
+spec_frontendState = do
+
+    it "is initialized with empty message queue" $ do
+        resp <- request methodGet "" [] ""
+        liftIO $ simpleBody resp `shouldBe` "[]"
+
+    it "posts accumulate into message queue" $ do
+        presp <- request methodPost "heya" [] ""
+        gresp <- request methodGet "" (getCookie presp) ""
+        liftIO $ simpleBody gresp `shouldBe`
+            (cs . show . fmap show $ [FrontendMsgSuccess "heya"])
+
+        presp2 <- request methodPost "ping" (getCookie gresp) ""
+        gresp2 <- request methodGet "" (getCookie presp2) ""
+        liftIO $ simpleBody gresp2 `shouldBe`
+            (cs . show . fmap show $ [FrontendMsgSuccess "ping", FrontendMsgSuccess "heya"])
+
+{-
+    it "something about exceptions..." $ do
+        pending
+-}
+
+
+getCookie :: SResponse -> RequestHeaders
+getCookie = fmap f . simpleHeaders
+  where
+    f ("Set-Cookie", c) = ("Cookie", c)
+    f hdr = hdr
+
+
+type TestApi =
+       Capture "id" ST :> Post '[JSON] ()
+  :<|> Get '[JSON] [ST]
+
+testApi :: ServerT TestApi FAction
+testApi = _post :<|> _read
+  where
+    _post msg = modify $ fsdMessages %~ (FrontendMsgSuccess msg :)
+    _read = gets ((cs . show <$>) . (^. fsdMessages))
+
+testApp :: IO Application
+testApp = createActionState "thentos_test" thentosTestConfig
+      >>= serveFAction (Proxy :: Proxy TestApi) testApi

--- a/thentos-tests/thentos-tests.cabal
+++ b/thentos-tests/thentos-tests.cabal
@@ -95,9 +95,12 @@ test-suite tests
   build-depends:
       aeson >=0.8.0.2 && <0.9
     , base >=4.8.1.0 && <5
+    , blaze-html
     , bytestring
     , containers >=0.5.6.2 && <0.6
     , cookie >=0.4.1.6 && <4.2
+    , digestive-functors
+    , digestive-functors-blaze
     , hspec >=2.1.10 && <2.3
     , hspec-wai >=0.6.3 && <0.7
     , http-types >=0.8.6 && <0.9
@@ -107,14 +110,11 @@ test-suite tests
     , postgresql-simple >=0.4.10 && <0.5
     , QuickCheck >=2.8.1 && <2.9
     , resource-pool >=0.2.3.2 && <0.3
-    , string-conversions >=0.4 && <0.5
     , servant
-    , servant-server
     , servant-blaze
-    , digestive-functors
-    , digestive-functors-blaze
-    , blaze-html
+    , servant-server
     , servant-session >=0.5 && <0.6
+    , string-conversions >=0.4 && <0.5
     , text >=1.2.1.3 && <1.3
     , thentos-core >=0.0.1.1 && <0.1
     , thentos-tests >=0.0.1.1 && <0.1

--- a/thentos-tests/thentos-tests.cabal
+++ b/thentos-tests/thentos-tests.cabal
@@ -97,6 +97,7 @@ test-suite tests
     , base >=4.8.1.0 && <5
     , bytestring
     , containers >=0.5.6.2 && <0.6
+    , cookie >=0.4.1.6 && <4.2
     , hspec >=2.1.10 && <2.3
     , hspec-wai >=0.6.3 && <0.7
     , http-types >=0.8.6 && <0.9
@@ -113,13 +114,16 @@ test-suite tests
     , digestive-functors
     , digestive-functors-blaze
     , blaze-html
+    , servant-session >=0.5 && <0.6
     , text >=1.2.1.3 && <1.3
     , thentos-core >=0.0.1.1 && <0.1
     , thentos-tests >=0.0.1.1 && <0.1
     , thyme >=0.3.5.5 && <0.4
     , transformers >=0.4.2.0 && <0.5
+    , vault >=0.3.0.4 && <3.1
     , wai >=3.0.3.0 && <3.1
     , wai-extra >=3.0.10 && <3.1
+    , wai-session >=0.3.2 && <0.4
     , webdriver >=0.6.2.1 && <0.7
 
 benchmark load-test


### PR DESCRIPTION
This is based on the servant-session package that was already available from a submodule in master.  That package allows to write a middleware that keeps track of a dynamically-typed key-value store accross requests using a cookie.  This patch adds a frontend monad `FAction` that carries a `StateT` value and a function that uses servant-session to keep that value in a cookie.

missing:
    - https://hackage.haskell.org/package/clientsession (for secrecy and integrity of the cookie contents)
    - frontend-specific errors (can probably fit in `OtherError`)