### PR TITLE
Integrate captcha into user registration workflow

### DIFF
--- a/docs/dev-howtos.md
+++ b/docs/dev-howtos.md
@@ -3,6 +3,20 @@
 This document describes some of our development practices. Please help it
 grow!
 
+## Source comment keywords
+
+We use the following greppable keywords in the source code with the
+resp.  specific meaning:
+
+- *TODO*: note to self to developer currently working on this piece of
+   code.  to be fixed before merge.  should never appear in master.
+- *FIXME*: this code is not elegant, but it is believed to work.
+   FIXME comments may appear on master and can be fixed, removed, or
+   ignored indefinitely without causing production issues.
+- *FUTUREWORK*: a less urgent sibling of *FIXME*.
+- *UPSTREAM*: could benefit from some work on the libraries we depend
+   on.  one common example for this are: `*.Missing` modules.
+
 ## Setup
 
 Please follow the instructions from the README file to initialize a cabal

--- a/docs/release_strategy.md
+++ b/docs/release_strategy.md
@@ -5,7 +5,7 @@
 
 2. Deviation of 1.: there are only few version constrainst in
    `thentos.cabal`.  Instead, we provide a `cabal.config` that pins
-   exactly and transitively all dependencies.  (FUTURE WORK: generate
+   exactly and transitively all dependencies.  (FUTUREWORK: generate
    `>=A.B.C.D && <A.B` constraints for `thentos.cabal` from
    `cabal.config`.)
 

--- a/thentos-adhocracy/tests/Thentos/Adhocracy3/Backend/Api/SimpleSpec.hs
+++ b/thentos-adhocracy/tests/Thentos/Adhocracy3/Backend/Api/SimpleSpec.hs
@@ -95,7 +95,7 @@ spec =
                  let userdata = mkUserJson "Anna Müller" "anna@" "EckVocUbs3"
                  fromA3UserWithPass <$>
                      (Aeson.eitherDecode userdata :: Either String A3UserWithPass)
-                     `shouldBe` Left "Not a valid email address: anna@"
+                     `shouldBe` Left "expected UserEmail, encountered String \"anna@\""
 
             it "rejects empty user names" $ do
                  let userdata = mkUserJson "" "anna@example.org" "EckVocUbs3"

--- a/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
@@ -173,6 +173,9 @@ instance ToCapture (Capture "sid" ServiceId) where
 instance ToCapture (Capture "uid" UserId) where
     toCapture _ = DocCapture "uid" "user ID"
 
+instance (ToSample a) => ToSample (JsonTop a) where
+    toSamples _ = second JsonTop <$> toSamples (Proxy :: Proxy a)
+
 instance ToSample Agent where
     toSamples _ = Docs.singleSample . UserA . UserId $ 0
 

--- a/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
@@ -200,6 +200,19 @@ instance ToSample UserEmail where
 instance ToSample UserId where
     toSamples _ = Docs.singleSample $ UserId 12
 
+instance ToSample CaptchaId where
+    toSamples _ = runTokenBuilder Action.freshCaptchaId
+
+instance ToSample CaptchaSolution where
+    toSamples _ = do
+      let cid :: CaptchaId = fromJustNote "ToSample CaptchaSolution failed unexpectedly" $
+                                          Docs.toSample (Proxy :: Proxy CaptchaId)
+      Docs.singleSample $ CaptchaSolution cid "someTeXT"
+
+instance ToSample UserCreationRequest where
+    toSamples _ = second (uncurry UserCreationRequest)
+                    <$> toSamples (Proxy :: Proxy (UserFormData, CaptchaSolution))
+
 instance ToSample ConfirmationToken where
     toSamples _ = runTokenBuilder Action.freshConfirmationToken
 

--- a/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
@@ -203,6 +203,9 @@ instance ToSample UserEmail where
 instance ToSample UserId where
     toSamples _ = Docs.singleSample $ UserId 12
 
+instance ToSample ImageData where
+    toSamples _ = Docs.singleSample $ ImageData "<large blob of unreadable binary gibberish>"
+
 instance ToSample CaptchaId where
     toSamples _ = runTokenBuilder Action.freshCaptchaId
 

--- a/thentos-core/src/Thentos/Backend/Api/Simple.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Simple.hs
@@ -187,11 +187,24 @@ instance HasDocExtras (RestDocs Api) where
 
 -- * servant foreign
 
--- | (Foreign.Elem is not exported, so we need to be slightly more restrictive.)
-instance Foreign.HasForeign (Post200 '[JSON] a) where
-    type Foreign (Post200 '[JSON] a) = Foreign.Req
+-- | FIXME: Foreign.Elem is only exported since https://github.com/haskell-servant/servant/pull/265
+-- which we don't have, so instead of:
+--
+-- >>> instance Elem JSON cts => HasForeign (Post200 cts a) where ...
+-- >>> instance Elem PNG cts => HasForeign (Post200 cts a) where ...
+--
+-- we more / less restrictive instances.  We should merge servant master in our submodule branch,
+-- though.
+instance {-# OVERLAPPABLE #-} Foreign.HasForeign (Post200 b a) where
+    type Foreign (Post200 b a) = Foreign.Req
     foreignFor Proxy req =
         req & Foreign.funcName  %~ ("post200" :)
+            & Foreign.reqMethod .~ "POST"
+
+instance {-# OVERLAPPING #-} Foreign.HasForeign (Post '[PNG] a) where
+    type Foreign (Post '[PNG] a) = Foreign.Req
+    foreignFor Proxy req =
+        req & Foreign.funcName  %~ ("post" :)
             & Foreign.reqMethod .~ "POST"
 
 -- FIXME: move this to module "Auth".

--- a/thentos-core/src/Thentos/Backend/Api/Simple.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Simple.hs
@@ -82,6 +82,7 @@ thentosBasic =
 
 type ThentosUser =
        ReqBody '[JSON] UserFormData :> Post '[JSON] UserId
+  :<|> "register" :> ReqBody '[JSON] UserCreationRequest :> Post '[JSON] UserId
   :<|> "login" :> ReqBody '[JSON] LoginFormData :> Post '[JSON] ThentosSessionToken
   :<|> Capture "uid" UserId :> Delete '[JSON] ()
   :<|> Capture "uid" UserId :> "name" :> Get '[JSON] UserName
@@ -90,6 +91,7 @@ type ThentosUser =
 thentosUser :: ServerT ThentosUser (Action Void ())
 thentosUser =
        addUser
+  :<|> addUnconfirmedUserWithCaptcha
   :<|> (\ (LoginFormData n p) -> snd <$> startThentosSessionByUserName n p)
   :<|> deleteUser
   :<|> (((^. userName) . snd) <$>) . lookupConfirmedUser

--- a/thentos-core/src/Thentos/Backend/Api/Simple.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Simple.hs
@@ -83,6 +83,7 @@ thentosBasic =
 type ThentosUser =
        ReqBody '[JSON] UserFormData :> Post '[JSON] UserId
   :<|> "register" :> ReqBody '[JSON] UserCreationRequest :> Post '[JSON] UserId
+  :<|> "activate" :> ReqBody '[JSON] ConfirmationToken :> Post '[JSON] ThentosSessionToken
   :<|> "login" :> ReqBody '[JSON] LoginFormData :> Post '[JSON] ThentosSessionToken
   :<|> Capture "uid" UserId :> Delete '[JSON] ()
   :<|> Capture "uid" UserId :> "name" :> Get '[JSON] UserName
@@ -92,7 +93,8 @@ thentosUser :: ServerT ThentosUser (Action Void ())
 thentosUser =
        addUser
   :<|> addUnconfirmedUserWithCaptcha
-  :<|> (\ (LoginFormData n p) -> snd <$> startThentosSessionByUserName n p)
+  :<|> (snd <$>) .  confirmNewUser
+  :<|> (\(LoginFormData n p) -> snd <$> startThentosSessionByUserName n p)
   :<|> deleteUser
   :<|> (((^. userName) . snd) <$>) . lookupConfirmedUser
   :<|> (((^. userEmail) . snd) <$>) . lookupConfirmedUser

--- a/thentos-core/src/Thentos/Backend/Core.hs
+++ b/thentos-core/src/Thentos/Backend/Core.hs
@@ -276,7 +276,7 @@ contentTypeJsonHeader = ("Content-Type", "application/json")
 
 -- | Cache-control headers in HTTP responses.  This is currently just a constant list of headers.
 --
--- FUTURE WORK: We may want for this to come from "Thentos.Config".  We may also want to the policy
+-- FUTUREWORK: We may want for this to come from "Thentos.Config".  We may also want to the policy
 -- to be a function in the request for which the response is constructed.  Not sure how best to
 -- combine these two requirements.
 httpCachePolicy :: HttpTypes.ResponseHeaders

--- a/thentos-core/src/Thentos/Backend/Core.hs
+++ b/thentos-core/src/Thentos/Backend/Core.hs
@@ -175,11 +175,13 @@ thentosErrorInfo other e = f e
         (Nothing, err404, "headers do not contain service id")
     f (ProxyNotConfiguredForService sid) =
         (Nothing, err404, "proxy not configured for service " <> cs (show sid))
-    f (NoSuchToken) =
+    f NoSuchToken =
         (Nothing, err400, "no such token")
     f (NeedUserA _ _) =
         (Nothing, err404,
             "thentos session belongs to service, cannot create service session")
+    f InvalidCaptchaSolution =
+        (Nothing, err400, "invalid solution supplied for captcha")
     f (MalformedUserPath path) =
         (Nothing, err400, "malformed user path: " <> cs (show path))
     f ConfirmationTokenAlreadyExists =

--- a/thentos-core/src/Thentos/Ends/Types.hs
+++ b/thentos-core/src/Thentos/Ends/Types.hs
@@ -25,6 +25,10 @@ import Thentos.Types
 
 -- * content types
 
+-- FUTUREWORK: we will need more of http://www.iana.org/assignments/media-types/media-types.xhtml,
+-- and we should probably add all of them either to the servant package or to a new package
+-- servant-content-types rather than here.
+
 -- | Html content type with pretty printing.  (See also: package servant-blaze.)
 type HTM = PrettyHTML
 

--- a/thentos-core/src/Thentos/Ends/Types.hs
+++ b/thentos-core/src/Thentos/Ends/Types.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE OverloadedStrings      #-}
+
+-- | Types required by both backend and frontend.
+module Thentos.Ends.Types
+    ( HTM
+    , renderHTM
+    , PrettyHTML
+    , TextCss
+    , PNG
+    )
+where
+
+import Data.Proxy (Proxy(Proxy))
+import Data.String.Conversions (ST, LT, SBS, LBS, cs)
+import Network.HTTP.Media ((//), (/:))
+import Servant.API (Accept (..), MimeRender (..))
+import Servant.HTML.Blaze (HTML)
+import Text.Blaze.Html (Html, ToMarkup, toHtml)
+import Text.Blaze.Html.Renderer.Pretty (renderHtml)
+
+import Thentos.Types
+
+
+-- * content types
+
+-- | Html content type with pretty printing.  (See also: package servant-blaze.)
+type HTM = PrettyHTML
+
+renderHTM :: Html -> LBS
+renderHTM = cs . renderHtml
+
+data PrettyHTML
+
+instance Accept PrettyHTML where
+    contentType _ = contentType (Proxy :: Proxy HTML)
+
+instance {-# OVERLAPPABLE #-} ToMarkup a => MimeRender PrettyHTML a where
+    mimeRender _ = renderHTM . toHtml
+
+instance {-# OVERLAPPING #-} MimeRender PrettyHTML Html where
+    mimeRender _ = renderHTM
+
+
+data TextCss
+
+instance Accept TextCss where
+    contentType _ = "text" // "css" /: ("charset", "utf-8")
+
+instance MimeRender TextCss LBS    where mimeRender _ = id
+instance MimeRender TextCss SBS    where mimeRender _ = cs
+instance MimeRender TextCss ST     where mimeRender _ = cs
+instance MimeRender TextCss LT     where mimeRender _ = cs
+instance MimeRender TextCss String where mimeRender _ = cs
+
+
+data PNG
+
+instance Accept PNG where
+    contentType _ = "image" // "png"
+
+instance MimeRender PNG ImageData where
+    mimeRender _ = cs . fromImageData

--- a/thentos-core/src/Thentos/Frontend.hs
+++ b/thentos-core/src/Thentos/Frontend.hs
@@ -26,6 +26,7 @@ import System.Log.Missing (logger)
 import Thentos.Action.Core
 import Thentos.Backend.Core
 import Thentos.Config
+import Thentos.Ends.Types
 import Thentos.Frontend.Handlers
 import Thentos.Frontend.Handlers.Combinators
 import Thentos.Frontend.State

--- a/thentos-core/src/Thentos/Frontend/Handlers.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers.hs
@@ -66,6 +66,7 @@ import qualified Data.Text.Encoding as STE
 import Thentos.Action
 import Thentos.Action.Core
 import Thentos.Backend.Core (addHeadersToResponse)
+import Thentos.Ends.Types
 import Thentos.Frontend.Handlers.Combinators
 import Thentos.Frontend.Pages
 import Thentos.Frontend.State

--- a/thentos-core/src/Thentos/Frontend/Types.hs
+++ b/thentos-core/src/Thentos/Frontend/Types.hs
@@ -13,53 +13,15 @@ import Control.Lens (makeLenses)
 import Control.Monad (mzero)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.ByteString.Builder (toLazyByteString)
-import Data.Proxy (Proxy(Proxy))
-import Data.String.Conversions (ST, LT, SBS, LBS, cs)
+import Data.String.Conversions (ST, SBS, cs)
 import GHC.Generics (Generic)
-import Servant.API (Accept (..), MimeRender (..))
-import Servant.HTML.Blaze (HTML)
-import Text.Blaze.Html (Html, ToMarkup, toHtml)
-import Text.Blaze.Html.Renderer.Pretty (renderHtml)
 import URI.ByteString (RelativeRef, serializeRelativeRef, parseRelativeRef, laxURIParserOptions)
 
 import qualified Data.Aeson as Aeson
 import qualified Generics.Generic.Aeson as Aeson
-import qualified Network.HTTP.Media as Media
 
 import Thentos.Types
 import Thentos.Action.Core (Action)
-
-
--- * content types
-
--- | Html content type with pretty printing.  (See also: package servant-blaze.)
-type HTM = PrettyHTML
-
-renderHTM :: Html -> LBS
-renderHTM = cs . renderHtml
-
-data PrettyHTML
-
-instance Accept PrettyHTML where
-    contentType _ = contentType (Proxy :: Proxy HTML)
-
-instance {-# OVERLAPPABLE #-} ToMarkup a => MimeRender PrettyHTML a where
-    mimeRender _ = renderHTM . toHtml
-
-instance {-# OVERLAPPING #-} MimeRender PrettyHTML Html where
-    mimeRender _ = renderHTM
-
-
-data TextCss
-
-instance Accept TextCss where
-    contentType _ = "text" Media.// "css" Media./: ("charset", "utf-8")
-
-instance MimeRender TextCss LBS    where mimeRender _ = id
-instance MimeRender TextCss SBS    where mimeRender _ = cs
-instance MimeRender TextCss ST     where mimeRender _ = cs
-instance MimeRender TextCss LT     where mimeRender _ = cs
-instance MimeRender TextCss String where mimeRender _ = cs
 
 
 -- * frontend actions

--- a/thentos-core/src/Thentos/Sybil/Captcha.hs
+++ b/thentos-core/src/Thentos/Sybil/Captcha.hs
@@ -11,4 +11,4 @@ import Thentos.Types
 -- solution to the captcha.
 -- FIXME Implement by delegating to hs-captcha or whatever captcha library we'll end up using
 generateCaptcha :: Random20 -> (ImageData, ST)
-generateCaptcha _random = ("", "")
+generateCaptcha _random = (ImageData "", "")

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -215,8 +215,15 @@ instance Aeson.FromJSON UserEmail
 instance Aeson.ToJSON UserEmail
     where toJSON = Aeson.toJSON . fromUserEmail
 
+
 newtype ConfirmationToken = ConfirmationToken { fromConfirmationToken :: ST }
     deriving (Eq, Ord, Show, Read, Typeable, Generic, ToField, FromField, IsString)
+
+instance Aeson.FromJSON ConfirmationToken where
+    parseJSON = Aeson.withText "confirmation token" (pure . ConfirmationToken)
+
+instance Aeson.ToJSON ConfirmationToken where toJSON (ConfirmationToken tok) = Aeson.toJSON tok
+
 
 instance FromHttpApiData ConfirmationToken where
     parseQueryParam tok = ConfirmationToken <$>

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -101,6 +101,7 @@ import Database.PostgreSQL.Simple.ToField (Action(Plain), ToField, inQuotes, toF
 import Database.PostgreSQL.Simple.TypeInfo.Static (interval)
 import Database.PostgreSQL.Simple.TypeInfo (typoid)
 import Data.ByteString.Builder (doubleDec)
+import Data.ByteString.Conversion (ToByteString)
 import Data.Char (isAlpha)
 import Data.EitherR (fmapL)
 import Data.Function (on)
@@ -713,12 +714,13 @@ newtype ImageData = ImageData { fromImageData :: SBS }
 
 
 newtype CaptchaId = CaptchaId { fromCaptchaId :: ST }
-  deriving (Eq, Ord, Show, Read, Typeable, Generic, IsString, FromField, ToField)
+  deriving (Eq, Ord, Show, Read, Typeable, Generic, IsString, FromField, ToField, ToByteString)
 
 instance Aeson.FromJSON CaptchaId where
     parseJSON = Aeson.withText "captcha ID string" (pure . CaptchaId)
 
 instance Aeson.ToJSON CaptchaId where toJSON (CaptchaId cid) = Aeson.toJSON cid
+
 
 
 data CaptchaSolution = CaptchaSolution

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -168,7 +168,7 @@ data ServiceAccount =
         -- ^ Do not give out any information about user beyond session token validity bit.  (not
         -- implemented.)
 
-        -- FUTURE WORK: what we actually would want here is "something" (type?  function?  something
+        -- FUTUREWORK: what we actually would want here is "something" (type?  function?  something
         -- more creative?)  that can be used as a filter on 'User' and will hide things from the
         -- service as appropriate.  we also want 'Service' to contain a counterpart "something".
         -- and a matcher that takes a service "something" and a user "something" and computes a

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -26,7 +26,8 @@ module Thentos.Types
     , UserEmail(..), parseUserEmail, fromUserEmail
     , ConfirmationToken(..)
     , PasswordResetToken(..)
-    , UserFormData (..)
+    , UserFormData(..)
+    , UserCreationRequest(..)
     , LoginFormData(..)
 
     , Service(..)
@@ -69,6 +70,7 @@ module Thentos.Types
     , Random20, mkRandom20, fromRandom20
     , ImageData(..)
     , CaptchaId(..)
+    , CaptchaSolution(..)
 
     , ThentosError(..)
 
@@ -238,6 +240,15 @@ data UserFormData =
 
 instance Aeson.FromJSON UserFormData where parseJSON = Aeson.gparseJson
 instance Aeson.ToJSON UserFormData where toJSON = Aeson.gtoJson
+
+data UserCreationRequest = UserCreationRequest
+    { ucUser    :: UserFormData
+    , ucCaptcha :: CaptchaSolution
+    }
+    deriving (Eq, Typeable, Generic)
+
+instance Aeson.FromJSON UserCreationRequest where parseJSON = Aeson.gparseJson
+instance Aeson.ToJSON UserCreationRequest where toJSON = Aeson.gtoJson
 
 data LoginFormData =
     LoginFormData
@@ -674,7 +685,7 @@ fromRandom20 (Random20 bs) = bs
 -- * binary data and captchas
 
 newtype ImageData = ImageData { fromImageData :: SBS }
-  deriving (Eq, Ord, Show, Read, Typeable, Generic, IsString, FromField, ToField)
+  deriving (Eq, Typeable, Generic)
 
 
 newtype CaptchaId = CaptchaId { fromCaptchaId :: ST }
@@ -684,6 +695,16 @@ instance Aeson.FromJSON CaptchaId where
     parseJSON = Aeson.withText "captcha ID string" (pure . CaptchaId)
 
 instance Aeson.ToJSON CaptchaId where toJSON (CaptchaId cid) = Aeson.toJSON cid
+
+
+data CaptchaSolution = CaptchaSolution
+    { csId       :: CaptchaId
+    , csSolution :: ST
+    }
+    deriving (Eq, Typeable, Generic)
+
+instance Aeson.FromJSON CaptchaSolution where parseJSON = Aeson.gparseJson
+instance Aeson.ToJSON CaptchaSolution where toJSON = Aeson.gtoJson
 
 
 -- * errors
@@ -718,6 +739,7 @@ data ThentosError e =
     | NoSuchToken
     | NeedUserA ThentosSessionToken ServiceId
     | MalformedUserPath ST
+    | InvalidCaptchaSolution
     | OtherError e
     deriving (Eq, Read, Show, Typeable)
 

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -142,8 +142,7 @@ import qualified Generics.Generic.Aeson as Aeson
 newtype JsonTop a = JsonTop { fromJsonTop :: a }
 
 instance (FromJSON a) => FromJSON (JsonTop a) where
-    parseJSON (Aeson.Object (H.toList -> [(key, val)]))
-        | key == "data"    = JsonTop <$> Aeson.parseJSON val
+    parseJSON (Aeson.Object (H.toList -> [("data", val)])) = JsonTop <$> Aeson.parseJSON val
     parseJSON _ = fail "Expected object with 'data' field"
 
 instance (ToJSON a) => ToJSON (JsonTop a) where

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -98,6 +98,7 @@ library
     , blaze-html >=0.8.1.0 && <0.9
     , blaze-markup >=0.7 && <0.8
     , bytestring >=0.10.6.0 && <0.11
+    , bytestring-conversion >=0.3.1 && <0.4
     , case-insensitive >=1.2.0.4 && <1.3
     , cond >=0.4 && <0.5
     , configifier >=0.0.6 && <0.1

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -68,6 +68,7 @@ library
     , Thentos.Backend.Api.Simple
     , Thentos.Backend.Core
     , Thentos.Config
+    , Thentos.Ends.Types
     , Thentos.Frontend
     , Thentos.Frontend.Handlers
     , Thentos.Frontend.Handlers.Combinators

--- a/thentos-tests/bench/Main.hs
+++ b/thentos-tests/bench/Main.hs
@@ -204,3 +204,14 @@ sessionCheckGen cfg sessionToken = Pronk.RequestGeneratorConstant $ Req req
   where
     req = (makeRequest cfg (Just sessionToken) "/thentos_session")
             {requestBody = RequestBodyLBS $ encode sessionToken }
+
+-- | Like 'Data.Aeson.decode' but allows all JSON values instead of just
+-- objects and arrays.
+--
+-- FIXME: upgrade to aeson >= 0.10 and use 'Aeson.eitherDecode' instead of this: See
+-- 4b370592242d4e4367ca46d852109c3927210f4b.  for this to work, we need to either upgrade pronk
+-- (criterion in particular) benchmarking or, preferably, factor it out into a separate package.
+decodeLenient :: Aeson.FromJSON a => LBS -> Either String a
+decodeLenient input = do
+    v :: Aeson.Value <- AP.parseOnly (Aeson.value <* AP.endOfInput) (cs input)
+    Aeson.parseEither Aeson.parseJSON v

--- a/thentos-tests/src/Thentos/Test/Core.hs
+++ b/thentos-tests/src/Thentos/Test/Core.hs
@@ -31,7 +31,7 @@ import Data.CaseInsensitive (mk)
 import Data.Maybe (fromJust)
 import Data.Monoid ((<>))
 import Data.Pool (Pool, withResource, destroyAllResources)
-import Data.String.Conversions (LBS, ST, cs)
+import Data.String.Conversions (ST, cs)
 import Data.Void (Void)
 import Database.PostgreSQL.Simple (Connection)
 import Network.HTTP.Types.Header (Header)
@@ -44,9 +44,7 @@ import System.Process (callCommand)
 import Test.Mockery.Directory (inTempDirectory)
 
 import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Parser as Aeson
 import qualified Data.Aeson.Types as Aeson
-import qualified Data.Attoparsec.ByteString as AP
 import qualified Test.WebDriver as WD
 
 import System.Log.Missing (loggerName)

--- a/thentos-tests/src/Thentos/Test/Core.hs
+++ b/thentos-tests/src/Thentos/Test/Core.hs
@@ -257,17 +257,6 @@ loginAsGod actionState = do
 
 -- * misc
 
--- | Like 'Data.Aeson.decode' but allows all JSON values instead of just
--- objects and arrays.
---
--- FIXME: upgrade to aeson >= 0.10 and use 'Aeson.eitherDecode' instead of this: See
--- 4b370592242d4e4367ca46d852109c3927210f4b.  for this to work, we need to either upgrade pronk
--- (criterion in particular) benchmarking or, preferably, factor it out into a separate package.
-decodeLenient :: Aeson.FromJSON a => LBS -> Either String a
-decodeLenient input = do
-    v :: Aeson.Value <- AP.parseOnly (Aeson.value <* AP.endOfInput) (cs input)
-    Aeson.parseEither Aeson.parseJSON v
-
 -- | This is convenient if you have lots of string literals with @-XOverloadedStrings@ but do not
 -- want to do explicit type signatures to avoid type ambiguity.
 (..=) :: ST -> ST -> Aeson.Pair

--- a/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
@@ -117,8 +117,8 @@ specRest = do
                 let Right (uid :: Int) = decodeJsonTop $ simpleBody response1
                 response2 <- request "GET" ("/user/" <> (cs . show $ uid) <> "/name") hdr ""
 
-                let Right top2 = decodeLenient $ simpleBody response2
-                liftIO $ fromJsonTop top2 `shouldBe` udName defaultUserData
+                let Right top2 = decodeJsonTop $ simpleBody response2
+                liftIO $ top2 `shouldBe` udName defaultUserData
 
             it "can only be called by admins" $
                     \ _ -> pendingWith "test missing."
@@ -344,7 +344,7 @@ specRest = do
 
 -- | Parse and unwrap an element wrapped in JsonTop. Returns the element, if parsing is successful,
 decodeJsonTop :: Aeson.FromJSON a => LBS -> Either String a
-decodeJsonTop bs = fromJsonTop <$> decodeLenient bs
+decodeJsonTop bs = fromJsonTop <$> Aeson.eitherDecode bs
 
 postDefaultUser :: WaiSession SResponse
 postDefaultUser = do

--- a/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
@@ -12,6 +12,8 @@
 {-# LANGUAGE TupleSections                            #-}
 {-# LANGUAGE TypeSynonymInstances                     #-}
 
+{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
+
 module Thentos.Backend.Api.SimpleSpec (spec, tests)
 where
 
@@ -20,7 +22,6 @@ import Control.Monad.State (liftIO)
 import Control.Monad (void)
 import Data.Configifier (Tagged(Tagged), (>>.))
 import Data.IORef (IORef, newIORef, writeIORef, readIORef)
-import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Data.Pool (Pool, withResource)
 import Data.Proxy (Proxy(Proxy))
@@ -158,8 +159,7 @@ specRest = do
             it "creates user if called with correct captcha solution" $ do
                 -- Get captcha and solution
                 crsp <- request "POST" "/user/captcha" [] ""
-                let cid = fromMaybe (error "/user/captcha didn't return Captcha-Id") .
-                                    lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
+                let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
                 connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
                 [Only solution] <- liftIO $ doQuery connPool
                     [sql| SELECT solution FROM captchas WHERE id = ? |] (Only cid)
@@ -171,8 +171,7 @@ specRest = do
             it "refuses to accept the same captcha solution twice" $ do
                 -- Get captcha and solution
                 crsp <- request "POST" "/user/captcha" [] ""
-                let cid = fromMaybe (error "/user/captcha didn't return Captcha-Id") .
-                                    lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
+                let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
                 connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
                 [Only solution] <- liftIO $ doQuery connPool
                     [sql| SELECT solution FROM captchas WHERE id = ? |] (Only cid)
@@ -190,8 +189,7 @@ specRest = do
                 void postDefaultUser
                 -- Get captcha and solution
                 crsp <- request "POST" "/user/captcha" [] ""
-                let cid = fromMaybe (error "/user/captcha didn't return Captcha-Id") .
-                                    lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
+                let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
                 connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
                 [Only solution] <- liftIO $ doQuery connPool
                     [sql| SELECT solution FROM captchas WHERE id = ? |] (Only cid)
@@ -214,8 +212,7 @@ specRest = do
 
             it "fails if called without correct captcha solution" $ do
                 crsp <- request "POST" "/user/captcha" [] ""
-                let cid = fromMaybe (error "/user/captcha didn't return Captcha-Id") .
-                                    lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
+                let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
                 let csol    = CaptchaSolution (CaptchaId $ cs cid) "probably wrong"
                     reqBody = Aeson.encode $ UserCreationRequest defaultUserData csol
                 request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 400
@@ -224,8 +221,7 @@ specRest = do
             it "activates a new user" $ do
                 -- Get captcha and solution
                 crsp <- request "POST" "/user/captcha" [] ""
-                let cid = fromMaybe (error "/user/captcha didn't return Captcha-Id") .
-                                    lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
+                let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
                 connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
                 [Only solution] <- liftIO $ doQuery connPool
                     [sql| SELECT solution FROM captchas WHERE id = ? |] (Only cid)
@@ -246,8 +242,7 @@ specRest = do
             it "fails if called again" $ do
                 -- Get captcha and solution
                 crsp <- request "POST" "/user/captcha" [] ""
-                let cid = fromMaybe (error "/user/captcha didn't return Captcha-Id") .
-                                    lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
+                let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
                 connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
                 [Only solution] <- liftIO $ doQuery connPool
                     [sql| SELECT solution FROM captchas WHERE id = ? |] (Only cid)
@@ -273,8 +268,7 @@ specRest = do
             it "logs an activated user in" $ do
                 -- Get captcha and solution
                 crsp <- request "POST" "/user/captcha" [] ""
-                let cid = fromMaybe (error "/user/captcha didn't return Captcha-Id") .
-                                    lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
+                let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
                 connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
                 [Only solution] <- liftIO $ doQuery connPool
                     [sql| SELECT solution FROM captchas WHERE id = ? |] (Only cid)
@@ -309,8 +303,7 @@ specRest = do
             it "fails if user isn't yet activated" $ do
                 -- Get captcha and solution
                 crsp <- request "POST" "/user/captcha" [] ""
-                let cid = fromMaybe (error "/user/captcha didn't return Captcha-Id") .
-                                    lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
+                let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
                 connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
                 [Only solution] <- liftIO $ doQuery connPool
                     [sql| SELECT solution FROM captchas WHERE id = ? |] (Only cid)

--- a/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
@@ -156,7 +156,7 @@ specRest = do
                 liftIO $ simpleBody rsp1 `shouldNotBe` simpleBody rsp2
 
         describe "register POST" $ do
-            it "creates user if called with correct captcha solution" $ do
+            it "responds with 201 if called with correct captcha solution" $ do
                 -- Get captcha and solution
                 crsp <- request "POST" "/user/captcha" [] ""
                 let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
@@ -168,7 +168,7 @@ specRest = do
                     reqBody = Aeson.encode $ UserCreationRequest defaultUserData csol
                 request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 201
 
-            it "refuses to accept the same captcha solution twice" $ do
+            it "refuses to accept the correct solution to the same captcha twice" $ do
                 -- Get captcha and solution
                 crsp <- request "POST" "/user/captcha" [] ""
                 let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp

--- a/thentos-tests/tests/Thentos/TransactionSpec.hs
+++ b/thentos-tests/tests/Thentos/TransactionSpec.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE QuasiQuotes         #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Thentos.TransactionSpec (spec) where


### PR DESCRIPTION
This resolves Task 41: change registration form validation to check for captcha.

The core API now has "/user/captcha", "/user/register", and "/user/activate" endpoints for creating a user who must be able to solve the captcha correctly. The tests are the best documentation of the workflow.

Suitable frontend (widget) is still missing and handled in a different task. Two other things are missing and will be addressed in different cases:

* If the user name is not unique, the user currently has to solve a new captcha instead of just entering a new name. There is a FIXME in one of the tests for this -- I propose to fix it in Task 42: handle the case that user enters wrong data.
* The "register" endpoint doesn't send out any confirmation emails yet, so the complete workflow doesn't currently work. This will be addressed by Task 60: Modify addUnconfirmedUser action to send emails.