### PR TITLE
A3 Compat DO NOT MERGE

### DIFF
--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
@@ -39,7 +39,6 @@ module Thentos.Adhocracy3.Backend.Api.Simple
     , thentosApi
     ) where
 
-import Data.Maybe (fromJust)
 import Control.Lens ((^.), (&), (<>~))
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad (when, mzero)
@@ -616,8 +615,7 @@ a3RenderUser uid _ = externalUrlOfDefaultPersona uid
 a3backendPath :: ThentosConfig -> ST -> Path
 a3backendPath config localPath = Path $ a3Prefix <//> localPath
   where
-    -- FIXME: get rid of the fromJust, a3-Prefix should not be optional
-    a3Prefix = fromJust $ config >>. (Proxy :: Proxy '["a3-prefix"])
+    a3Prefix = config >>. (Proxy :: Proxy '["a3-prefix"])
 
 userIdFromPath :: MonadError (ThentosError e) m => Path -> m UserId
 userIdFromPath (Path s) = do

--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
@@ -609,13 +609,7 @@ renderA3HeaderName h                    = renderThentosHeaderName h
 
 -- | Render the user as A3 expects it. We return the external URL of the user's default persona.
 a3RenderUser :: UserId -> User -> A3Action SBS
-a3RenderUser uid _ = do
-    sid     <- a3ServiceId
-    persona <- A.findPersona uid sid "" >>=
-               maybe (throwError . OtherError $ A3NoDefaultPersona uid sid) pure
-    userUrl <- maybe (throwError $ OtherError A3PersonaLacksExternalUrl) pure $
-                     persona ^. personaExternalUrl
-    return . URI.uriPath $ fromUri userUrl
+a3RenderUser uid _ = externalUrlOfDefaultPersona uid
 
 -- | Convert a local file name into a absolute path relative to the A3 backend endpoint.  (Returns
 -- exposed url.)

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -64,7 +64,7 @@ type ThentosConfig' =
   :*>       ("mail"         :> MailConfig'           :>: "Mail templates")
     -- TODO: a3-prefix should not live in thentos-core
     -- TODO: maybe make this a more structured type than ST
-  :*> Maybe ("a3-prefix"    :> ST                    :>: "URL prefix of the A3 api")
+  :*>       ("a3-prefix"    :> ST                    :>: "URL prefix of the A3 api")
 
 defaultThentosConfig :: ToConfig (ToConfigCode ThentosConfig') Maybe
 defaultThentosConfig =
@@ -83,7 +83,7 @@ defaultThentosConfig =
   :*> NothingO
   :*> Nothing
   :*> Just defaultMailConfig
-  :*> NothingO
+  :*> Nothing
 
 type HttpConfig = Tagged (ToConfigCode HttpConfig')
 type HttpConfig' =

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -62,6 +62,9 @@ type ThentosConfig' =
   :*> Maybe ("gc_interval"             :> Timeout    :>: "Garbage collection interval")
   :*>       ("log"          :> LogConfig'            :>: "Logging")
   :*>       ("mail"         :> MailConfig'           :>: "Mail templates")
+    -- TODO: a3-prefix should not live in thentos-core
+    -- TODO: maybe make this a more structured type than ST
+  :*> Maybe ("a3-prefix"    :> ST                    :>: "URL prefix of the A3 api")
 
 defaultThentosConfig :: ToConfig (ToConfigCode ThentosConfig') Maybe
 defaultThentosConfig =
@@ -80,6 +83,7 @@ defaultThentosConfig =
   :*> NothingO
   :*> Nothing
   :*> Just defaultMailConfig
+  :*> NothingO
 
 type HttpConfig = Tagged (ToConfigCode HttpConfig')
 type HttpConfig' =


### PR DESCRIPTION
My current idea how to solve https://tree.taiga.io/project/fisx-thentos/task/37 is that instead of putting the entire user resource URL in the `X-User-Path` header, we can just put the path component of the header. I've tried this on an older version of thentos and it seems to fix the problem. I haven't managed to test this with this version of thentos, though, since the email sending functionality seems to be broken, so I cannot create a user to log in with. (thentos crashes with `ActionErrorUnknown sendUserConfirmationMail: no such context`, where the argument to `context` seems to be `frontend_url`.