### PR TITLE
Define separate deleteCaptcha (trans)action called only after user creation

### DIFF
--- a/thentos-core/src/Thentos/Action.hs
+++ b/thentos-core/src/Thentos/Action.hs
@@ -80,6 +80,7 @@ module Thentos.Action
 
     , makeCaptcha
     , solveCaptcha
+    , deleteCaptcha
 
     , collectGarbage
     )
@@ -208,13 +209,17 @@ addUnconfirmedUser userData = do
     return (uid, tok)
 
 -- | Initiate email-verified user creation.  Does not require any privileges, but the user must
--- have correctly solved a captcha to prove that they are human.  See also:
--- 'makeCaptcha', 'confirmNewUser'.
+-- have correctly solved a captcha to prove that they are human.  After the new user has been
+-- created, the captcha is deleted to prevent an attacker from creating multiple users after
+-- solving one captcha.  If user creation fails (e.g. because of a duplicate user name), the
+-- captcha remain in the DB to allow another attempt.  See also: 'makeCaptcha', 'confirmNewUser'.
 addUnconfirmedUserWithCaptcha :: (Show e, Typeable e) => UserCreationRequest -> Action e s UserId
 addUnconfirmedUserWithCaptcha ucr = do
     unlessM (solveCaptcha (csId $ ucCaptcha ucr) (csSolution $ ucCaptcha ucr)) $
         throwError InvalidCaptchaSolution
-    fst <$> addUnconfirmedUser (ucUser ucr)
+    uid <- fst <$> addUnconfirmedUser (ucUser ucr)
+    deleteCaptcha . csId $ ucCaptcha ucr
+    pure uid
 
 -- | Finish email-verified user creation. Throws 'NoSuchPendingUserConfirmation' if the
 -- token doesn't exist or is expired.
@@ -679,13 +684,16 @@ makeCaptcha = do
     pure (cid, imgdata)
 
 -- | Submit a solution to a captcha, returning whether or not the solution is correct.
--- Calling this action deletes the referenced captcha from the DB, so every captcha must be
--- solved (or not) at first attempt. Throws 'NoSuchCaptchaId' if the given 'CaptchaId' doesn't
--- exist in the DB (either because it never did or because it was deleted due to garbage collection
--- or a prior call to this action). Does not require any privileges.
+-- Throws 'NoSuchCaptchaId' if the given 'CaptchaId' doesn't exist in the DB (either because it
+-- never did or because it was deleted). Does not require any privileges.
 solveCaptcha :: CaptchaId -> ST -> Action e s Bool
 solveCaptcha cid solution = query'P $ T.solveCaptcha cid solution
 
+-- | Delete a captcha and its solution from the DB. Throws 'NoSuchCaptchaId' if the given
+-- 'CaptchaId' doesn't exist in the DB (either because it never did or because it was deleted due
+-- to garbage collection or a prior call to this action). Does not require any privileges.
+deleteCaptcha :: CaptchaId -> Action e s ()
+deleteCaptcha = query'P . T.deleteCaptcha
 
 -- * garbage collection
 

--- a/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
@@ -196,7 +196,6 @@ specRest = do
                 -- Try again using a new user name
                 let user2    = user { udName = "newname" }
                     reqBody2 = Aeson.encode $ UserCreationRequest user2 csol
-                liftIO $ pendingWith "FIXME not correctly implemented yet"
                 request "POST" "/user/register" jsonHeader reqBody2 `shouldRespondWith` 201
 
             it "fails if called without correct captcha ID" $ do


### PR DESCRIPTION
This allows the frontend to submit fresh data if user creation fails e.g. because of a duplicate user name, without forcing the user to solve another captcha.

Solves Task 42: handle the case that user enters wrong data.