### PR TITLE
Modify addUnconfirmedUser action to send emails

### DIFF
--- a/devel.config
+++ b/devel.config
@@ -33,3 +33,29 @@ database:
 
 purescript:
     "./thentos-purescript/static/"
+
+mail:
+    account_verification:
+        subject: "Thentos: Aktivierung Ihres Nutzerkontos"
+        # Supported variables: {{user_name}}, {{activation_url}}
+        body: |
+            Hallo {{user_name}},
+
+            vielen Dank für Ihre Registrierung bei Thentos.
+
+            Diese E-Mail dient der Validierung Ihrer Identität. Bitte
+            nutzen Sie den folgenden Link um das Nutzerkonto zu aktivieren.
+
+            {{activation_url}}
+
+            Wir wünschen Ihnen viel Spaß und Inspiration!
+
+            Das Thentos-Team
+    user_exists:
+        subject: "Thentos: Attempted Signup"
+        body: |
+            Someone tried to sign up to Thentos with your email address.
+
+            This is a reminder that you already have a Thentos account. If you
+            haven't tried to sign up to Thentos, you can just ignore this email.
+            If you have, you are hereby reminded that you already have an account.

--- a/thentos-adhocracy/devel.config
+++ b/thentos-adhocracy/devel.config
@@ -69,3 +69,11 @@ mail:
             Wir wünschen Ihnen viel Spaß und Inspiration!
 
             Das Thentos-Team
+    user_exists:
+        subject: "Thentos: Attempted Signup"
+        body: |
+            Someone tried to sign up to Thentos with your email address.
+
+            This is a reminder that you already have a Thentos account. If you
+            haven't tried to sign up to Thentos, you can just ignore this email.
+            If you have, you are hereby reminded that you already have an account.

--- a/thentos-adhocracy/thentos-adhocracy.cabal
+++ b/thentos-adhocracy/thentos-adhocracy.cabal
@@ -48,7 +48,6 @@ library
     , case-insensitive >=1.2.0.4 && <1.3
     , configifier >=0.0.6 && <0.1
     , functor-infix >=0.0.3 && <0.1
-    , hastache >= 0.6.1 && <0.7
     , hslogger >=1.2.9 && <1.3
     , http-client >=0.4.22 && <0.5
     , http-conduit >=2.1.8 && <2.2

--- a/thentos-core/src/Thentos/Action.hs
+++ b/thentos-core/src/Thentos/Action.hs
@@ -98,6 +98,8 @@ import GHC.Exception (Exception)
 import LIO.DCLabel ((%%), (\/), (/\))
 import LIO.Error (AnyLabelError)
 import System.Log.Logger (Priority(DEBUG))
+import Text.Hastache.Context (mkStrContext)
+import Text.Hastache (MuType(MuVariable))
 
 import qualified Codec.Binary.Base64 as Base64
 import qualified Data.Text as ST
@@ -105,6 +107,7 @@ import qualified Data.Text as ST
 import LIO.Missing
 import Thentos.Action.Core
 import Thentos.Action.SimpleAuth
+import Thentos.Config
 import Thentos.Transaction.Core (ThentosQuery)
 import Thentos.Types
 import Thentos.Util
@@ -196,25 +199,56 @@ deleteUser uid = do
 
 -- ** email confirmation
 
--- | Initiate email-verified user creation.  Does not require any privileges.  See also:
--- 'confirmNewUser'.
-addUnconfirmedUser :: (Show e, Typeable e) => UserFormData -> Action e s (UserId, ConfirmationToken)
+-- | Initiate email-verified user creation.  Does not require any privileges.
+-- This also sends an email containing an activation link on which the user must click.
+-- See also: 'confirmNewUser'.
+addUnconfirmedUser :: (Show e, Typeable e) => UserFormData -> Action e s ()
 addUnconfirmedUser userData = do
     -- FIXME change action to send the email directly instead of just returning the token
     -- and letting the frontend do it
     tok  <- freshConfirmationToken
     user <- makeUserFromFormData'P userData
-    uid  <- query'P $ T.addUnconfirmedUser tok user
-    return (uid, tok)
+    let happy = do
+            void . query'P $ T.addUnconfirmedUser tok user
+            sendUserConfirmationMail userData tok
+    happy
+        `catchError`
+            \case UserEmailAlreadyExists -> sendUserExistsMail (udEmail userData)
+                  e                      -> throwError e
+
+-- | Helper action: Send a confirmation mail to a newly registered user.
+sendUserConfirmationMail :: UserFormData -> ConfirmationToken -> Action e s ()
+sendUserConfirmationMail user (ConfirmationToken confToken) = do
+    cfg <- getConfig'P
+    let smtpCfg :: SmtpConfig = Tagged $ cfg >>. (Proxy :: Proxy '["smtp"])
+        subject      = cfg >>. (Proxy :: Proxy '["mail", "account_verification", "subject"])
+        bodyTemplate = cfg >>. (Proxy :: Proxy '["mail", "account_verification", "body"])
+        feHttp       = case cfg >>. (Proxy :: Proxy '["frontend"]) of
+                          Nothing -> error "sendUserConfirmationMail: frontend not configured!"
+                          Just v -> Tagged v
+        context "user_name"      = MuVariable . fromUserName $ udName user
+        context "activation_url" = MuVariable $ exposeUrl feHttp <//> "/activate/" <//> confToken
+        context _                = error "sendUserConfirmationMail: no such context"
+    body <- renderTextTemplate'P bodyTemplate (mkStrContext context)
+    sendMail'P smtpCfg (Just $ udName user) (udEmail user) subject $ cs body
+
+-- | Helper action: Send a confirmation mail to a newly registered user.
+sendUserExistsMail :: UserEmail -> Action e s ()
+sendUserExistsMail email = do
+    cfg <- getConfig'P
+    let smtpCfg :: SmtpConfig = Tagged $ cfg >>. (Proxy :: Proxy '["smtp"])
+        subject = cfg >>. (Proxy :: Proxy '["mail", "user_exists", "subject"])
+        body    = cfg >>. (Proxy :: Proxy '["mail", "user_exists", "body"])
+    sendMail'P smtpCfg Nothing email subject body
 
 -- | Initiate email-verified user creation.  Does not require any privileges, but the user must
 -- have correctly solved a captcha to prove that they are human.  See also:
 -- 'makeCaptcha', 'confirmNewUser'.
-addUnconfirmedUserWithCaptcha :: (Show e, Typeable e) => UserCreationRequest -> Action e s UserId
+addUnconfirmedUserWithCaptcha :: (Show e, Typeable e) => UserCreationRequest -> Action e s ()
 addUnconfirmedUserWithCaptcha ucr = do
     unlessM (solveCaptcha (csId $ ucCaptcha ucr) (csSolution $ ucCaptcha ucr)) $
         throwError InvalidCaptchaSolution
-    fst <$> addUnconfirmedUser (ucUser ucr)
+    addUnconfirmedUser (ucUser ucr)
 
 -- | Finish email-verified user creation. Throws 'NoSuchPendingUserConfirmation' if the
 -- token doesn't exist or is expired.

--- a/thentos-core/src/Thentos/Backend/Api/Simple.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Simple.hs
@@ -89,7 +89,7 @@ thentosBasic =
 
 type ThentosUser =
        ReqBody '[JSON] UserFormData :> Post '[JSON] (JsonTop UserId)
-  :<|> "register" :> ReqBody '[JSON] UserCreationRequest :> Post '[JSON] (JsonTop UserId)
+  :<|> "register" :> ReqBody '[JSON] UserCreationRequest :> Post '[JSON] ()
   :<|> "activate" :> ReqBody '[JSON] (JsonTop ConfirmationToken)
                   :> Post '[JSON] (JsonTop ThentosSessionToken)
   :<|> "login" :> ReqBody '[JSON] LoginFormData :> Post '[JSON] (JsonTop ThentosSessionToken)
@@ -101,7 +101,7 @@ type ThentosUser =
 thentosUser :: ServerT ThentosUser (Action Void ())
 thentosUser =
        (JsonTop <$>) . addUser
-  :<|> (JsonTop <$>) . addUnconfirmedUserWithCaptcha
+  :<|> addUnconfirmedUserWithCaptcha
   :<|> (JsonTop <$>) . (snd <$>) .  confirmNewUser . fromJsonTop
   :<|> (\(LoginFormData n p) -> JsonTop . snd <$> startThentosSessionByUserName n p)
   :<|> deleteUser

--- a/thentos-core/src/Thentos/Backend/Api/Simple.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Simple.hs
@@ -89,6 +89,9 @@ thentosBasic =
 
 type ThentosUser =
        ReqBody '[JSON] UserFormData :> Post '[JSON] (JsonTop UserId)
+       -- register returns 204 No Content
+       -- FIXME We should use '[] instead of '[JSON] as result type for UserCreationRequest,
+       -- but that causes a compile error at "serve p (restDocs ..."
   :<|> "register" :> ReqBody '[JSON] UserCreationRequest :> Post '[JSON] ()
   :<|> "activate" :> ReqBody '[JSON] (JsonTop ConfirmationToken)
                   :> Post '[JSON] (JsonTop ThentosSessionToken)

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -134,20 +134,34 @@ type LogConfig' =
     :*> ("level" :> Prio)
 
 type MailConfig = Tagged (ToConfigCode MailConfig')
-type MailConfig' = "account_verification" :> AccountVerificationConfig'
+type MailConfig' =
+        "account_verification" :> AccountVerificationConfig'
+    :*> "user_exists"          :> UserExistsConfig'
 
 type AccountVerificationConfig = Tagged (ToConfigCode AccountVerificationConfig')
 type AccountVerificationConfig' =
       ("subject" :> ST)
   :*> ("body"    :> ST)
 
+type UserExistsConfig = Tagged (ToConfigCode UserExistsConfig')
+type UserExistsConfig' =
+      ("subject" :> ST)
+  :*> ("body"    :> ST)
+
 defaultMailConfig :: ToConfig (ToConfigCode MailConfig') Maybe
-defaultMailConfig = Just defaultAccountVerificationConfig
+defaultMailConfig =
+        Just defaultAccountVerificationConfig
+    :*> Just defaultUserExistsConfig
 
 defaultAccountVerificationConfig :: ToConfig (ToConfigCode AccountVerificationConfig') Maybe
 defaultAccountVerificationConfig =
       Just "Thentos account creation confirmation"
   :*> Just "Please go to {{activation_url}} to confirm your account."
+
+defaultUserExistsConfig :: ToConfig (ToConfigCode UserExistsConfig') Maybe
+defaultUserExistsConfig =
+      Just "Thentos: Attempted Signup"
+  :*> Just "Someone tried to sign up to Thentos with your email address."
 
 
 -- * leaf types

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -76,6 +76,9 @@ thentosTestConfig = unsafePerformIO . configify . (:[]) . YamlString . cs . unli
     "            bitte nutzen Sie den folgenden Link um das Nutzerkonto zu aktivieren." :
     "" :
     "            {{activation_url}}" :
+    "    user_exists:" :
+    "        subject: \"Thentos: Attempted Signup\"" :
+    "        body: \"Someone tried to sign up to Thentos with your email address.\"" :
     []
 
 godUid :: UserId


### PR DESCRIPTION
Registration emails are now sent by the addUnconfirmedUser action instead of by its callers. Hence all interfaces (core/REST, core/HTML, a3) will behave in the same way and there is no duplication of functionality.

Resolves Task 60: Modify addUnconfirmedUser action to send emails.