### PR TITLE
Tweak Config structure re. email templates

### DIFF
--- a/devel.config
+++ b/devel.config
@@ -34,7 +34,7 @@ database:
 purescript:
     "./thentos-purescript/static/"
 
-mail:
+email_templates:
     account_verification:
         subject: "Thentos: Aktivierung Ihres Nutzerkontos"
         # Supported variables: {{user_name}}, {{activation_url}}

--- a/thentos-adhocracy/devel.config
+++ b/thentos-adhocracy/devel.config
@@ -52,7 +52,7 @@ log:
 database:
     name: "thentosdev"
 
-mail:
+email_templates:
     account_verification:
         subject: "Thentos: Aktivierung Ihres Nutzerkontos"
         # Supported variables: {{user_name}}, {{activation_url}}

--- a/thentos-core/src/Thentos/Action.hs
+++ b/thentos-core/src/Thentos/Action.hs
@@ -222,11 +222,11 @@ sendUserConfirmationMail :: UserFormData -> ConfirmationToken -> Action e s ()
 sendUserConfirmationMail user (ConfirmationToken confToken) = do
     cfg <- getConfig'P
     let smtpCfg :: SmtpConfig = Tagged $ cfg >>. (Proxy :: Proxy '["smtp"])
-        subject      = cfg >>. (Proxy :: Proxy '["mail", "account_verification", "subject"])
-        bodyTemplate = cfg >>. (Proxy :: Proxy '["mail", "account_verification", "body"])
-        feHttp       = case cfg >>. (Proxy :: Proxy '["frontend"]) of
-                          Nothing -> error "sendUserConfirmationMail: frontend not configured!"
-                          Just v -> Tagged v
+        subject = cfg >>. (Proxy :: Proxy '["email_templates", "account_verification", "subject"])
+        bodyTemplate = cfg >>. (Proxy :: Proxy '["email_templates", "account_verification", "body"])
+        feHttp = case cfg >>. (Proxy :: Proxy '["frontend"]) of
+            Nothing -> error "sendUserConfirmationMail: frontend not configured!"
+            Just v -> Tagged v
         context "user_name"      = MuVariable . fromUserName $ udName user
         context "activation_url" = MuVariable $ exposeUrl feHttp <//> "/activate/" <//> confToken
         context _                = error "sendUserConfirmationMail: no such context"
@@ -238,8 +238,8 @@ sendUserExistsMail :: UserEmail -> Action e s ()
 sendUserExistsMail email = do
     cfg <- getConfig'P
     let smtpCfg :: SmtpConfig = Tagged $ cfg >>. (Proxy :: Proxy '["smtp"])
-        subject = cfg >>. (Proxy :: Proxy '["mail", "user_exists", "subject"])
-        body    = cfg >>. (Proxy :: Proxy '["mail", "user_exists", "body"])
+        subject = cfg >>. (Proxy :: Proxy '["email_templates", "user_exists", "subject"])
+        body    = cfg >>. (Proxy :: Proxy '["email_templates", "user_exists", "body"])
     sendMail'P smtpCfg Nothing email subject body
 
 -- | Initiate email-verified user creation.  Does not require any privileges, but the user must

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -61,7 +61,7 @@ type ThentosConfig' =
   :*>       ("captcha_expiration"      :> Timeout    :>: "Captcha expiration period")
   :*> Maybe ("gc_interval"             :> Timeout    :>: "Garbage collection interval")
   :*>       ("log"          :> LogConfig'            :>: "Logging")
-  :*>       ("mail"         :> MailConfig'           :>: "Mail templates")
+  :*>       ("email_templates" :> EmailTemplates'    :>: "Mail templates")
 
 defaultThentosConfig :: ToConfig (ToConfigCode ThentosConfig') Maybe
 defaultThentosConfig =
@@ -79,7 +79,7 @@ defaultThentosConfig =
   :*> Just (fromHours 1)
   :*> NothingO
   :*> Nothing
-  :*> Just defaultMailConfig
+  :*> Just defaultEmailTemplates
 
 type HttpConfig = Tagged (ToConfigCode HttpConfig')
 type HttpConfig' =
@@ -133,35 +133,20 @@ type LogConfig' =
         ("path" :> ST)
     :*> ("level" :> Prio)
 
-type MailConfig = Tagged (ToConfigCode MailConfig')
-type MailConfig' =
-        "account_verification" :> AccountVerificationConfig'
-    :*> "user_exists"          :> UserExistsConfig'
+type EmailTemplates = Tagged (ToConfigCode EmailTemplates')
+type EmailTemplates' =
+        "account_verification" :> EmailTemplate'
+    :*> "user_exists"          :> EmailTemplate'
 
-type AccountVerificationConfig = Tagged (ToConfigCode AccountVerificationConfig')
-type AccountVerificationConfig' =
+type EmailTemplate = Tagged (ToConfigCode EmailTemplate')
+type EmailTemplate' =
       ("subject" :> ST)
   :*> ("body"    :> ST)
 
-type UserExistsConfig = Tagged (ToConfigCode UserExistsConfig')
-type UserExistsConfig' =
-      ("subject" :> ST)
-  :*> ("body"    :> ST)
-
-defaultMailConfig :: ToConfig (ToConfigCode MailConfig') Maybe
-defaultMailConfig =
-        Just defaultAccountVerificationConfig
-    :*> Just defaultUserExistsConfig
-
-defaultAccountVerificationConfig :: ToConfig (ToConfigCode AccountVerificationConfig') Maybe
-defaultAccountVerificationConfig =
-      Just "Thentos account creation confirmation"
-  :*> Just "Please go to {{activation_url}} to confirm your account."
-
-defaultUserExistsConfig :: ToConfig (ToConfigCode UserExistsConfig') Maybe
-defaultUserExistsConfig =
-      Just "Thentos: Attempted Signup"
-  :*> Just "Someone tried to sign up to Thentos with your email address."
+defaultEmailTemplates :: ToConfig (ToConfigCode EmailTemplates') Maybe
+defaultEmailTemplates =
+        Nothing
+    :*> Nothing
 
 
 -- * leaf types

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -67,7 +67,7 @@ thentosTestConfig = unsafePerformIO . configify . (:[]) . YamlString . cs . unli
     "database:" :
     "    name: unused" :
     "" :
-    "mail:" :
+    "email_templates:" :
     "    account_verification:" :
     "        subject: \"Thentos: Aktivierung Ihres Nutzerkontos\"" :
     "        body: |" :


### PR DESCRIPTION
- more expressive names for yaml lables and types
- one type for all templates (not one for each)
- no built-in default templates in thentos-core