### PR TITLE
Make thentos stick to User-Path format expected by A3

### DIFF
--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
@@ -622,8 +622,9 @@ userIdFromPath (Path s) = do
     uri <- either (const . throwError . MalformedUserPath $ s) return $
         URI.parseURI URI.laxURIParserOptions $ cs s
     rawId <- maybe (throwError $ MalformedUserPath s) return $
-        -- FIXME: I don't think this will work, as the path may be something
+        -- BUG (I think) : I don't think this will work, as the path may be something
         --  like /foo/principals/users/ (see https://github.com/liqd/adhocracy3/pull/1849)
+        -- github issue at https://github.com/liqd/thentos/issues/411
         stripPrefix "/principals/users/" $ dropWhileEnd (== '/') (cs $ URI.uriPath uri)
     maybe (throwError NoSuchUser) (return . UserId) $ readMay rawId
 

--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
@@ -39,7 +39,6 @@ module Thentos.Adhocracy3.Backend.Api.Simple
     , thentosApi
     ) where
 
-import Data.Maybe (fromJust)
 import Control.Lens ((^.), (&), (<>~))
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad (when, mzero)
@@ -616,8 +615,7 @@ a3RenderUser uid _ = externalUrlOfDefaultPersona uid
 a3backendPath :: ThentosConfig -> ST -> Path
 a3backendPath config localPath = Path $ a3Prefix <//> localPath
   where
-    -- FIXME: get rid of the fromJust, a3-Prefix should not be optional
-    a3Prefix = fromJust $ config >>. (Proxy :: Proxy '["a3-prefix"])
+    a3Prefix = config >>. (Proxy :: Proxy '["a3-prefix"])
 
 userIdFromPath :: MonadError (ThentosError e) m => Path -> m UserId
 userIdFromPath (Path s) = do

--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
@@ -424,9 +424,9 @@ addUser (A3UserWithPass user) = AC.logIfError'P $ do
     -- possible solution: deliver thentos registration widget; disable all adhocracy frontend-code
     -- that touches this end-point; provide user resources from outside of widgets only.
 
--- | Activate a new user. This also creates a persona and a corresponding adhocracy user in the A3 backend,
--- so that the user is able to log into A3. The user's actual password and email address are
--- only stored in Thentos and NOT exposed to A3.
+-- | Activate a new user. This also creates a persona and a corresponding adhocracy user in the A3
+-- backend, so that the user is able to log into A3. The user's actual password and email address
+-- are only stored in Thentos and NOT exposed to A3.
 activate :: ActivationRequest -> A3Action RequestResult
 activate ar@(ActivationRequest confToken) = AC.logIfError'P $ do
     AC.logger'P DEBUG . ("route activate:" <>) . cs $ Aeson.encodePretty ar

--- a/thentos-adhocracy/tests/Thentos/Adhocracy3/Backend/Api/SimpleSpec.hs
+++ b/thentos-adhocracy/tests/Thentos/Adhocracy3/Backend/Api/SimpleSpec.hs
@@ -37,7 +37,8 @@ import Network.Wai (Application)
 import Network.Wai.Handler.Warp (defaultSettings, setHost, setPort, runSettings)
 import Network.Wai.Test (simpleBody, simpleStatus)
 import System.Process (readProcess)
-import Test.Hspec (Spec, around_, describe, hspec, it, shouldBe, shouldSatisfy, pendingWith)
+import Test.Hspec (Spec, around_, describe, hspec, it,
+                   shouldBe, shouldContain, shouldSatisfy, pendingWith)
 import Test.Hspec.Wai (request, with)
 import Test.QuickCheck (Arbitrary(..), property)
 
@@ -143,6 +144,9 @@ spec =
                         -- The returned path is now just a dummy that uses our endpoint prefix
                         -- (not the one from A3)
                         ["http://127.0.0.1:7118/"]
+                          -- TODO: this test fails because the content_type field in the body is now
+                          -- a path without scheme and authority.  (losely related: the path does
+                          -- not start with a '/'.  should it?)
 
                         -- FIXME: we should change Thentos.Test.Config.{back,front}end to so that we
                         -- can distinguish between bind url and exposed url.  i think this here
@@ -235,7 +239,7 @@ spec =
                 let rspBody = simpleBody rsp
                 liftIO $ (Aeson.decode rspBody :: Maybe Aeson.Value) `shouldSatisfy` isJust
                 -- It should contain the quoted string "internal error"
-                liftIO $ (cs rspBody :: ST) `shouldSatisfy` ST.isInfixOf "\"internal error\""
+                liftIO $ cs rspBody `shouldContain` ("\"internal error\"" :: String)
 
   where
     setupBackend :: IO Application
@@ -256,19 +260,19 @@ spec =
 -- | Compare the response status with an expected status code and check that the response
 -- body is a JSON object that contains all of the specified custom strings.
 shouldBeStatusXWithCustomMessages :: MonadIO m => (?loc :: CallStack) =>
-    Int -> Status.Status -> LBS -> [ST] -> m ()
+    Int -> Status.Status -> LBS -> [String] -> m ()
 shouldBeStatusXWithCustomMessages expectedCode rstStatus rspBody customMessages = do
     liftIO $ Status.statusCode rstStatus `shouldBe` expectedCode
     -- Response body should be parseable as JSON
     liftIO $ (Aeson.decode rspBody :: Maybe Aeson.Value) `shouldSatisfy` isJust
     let rspText = cs rspBody :: ST
-    liftIO $ for_ customMessages $ \customMessage ->
-        rspText `shouldSatisfy` ST.isInfixOf customMessage
+    liftIO $ for_ customMessages (cs rspText `shouldContain`)
+
 
 -- | Like 'shouldBeStatusXWithCustomMessage', with the expected code set tu 400.
 -- We check the custom messages and the quoted string "error" are present in the JSON body.
 shouldBeErr400WithCustomMessage :: MonadIO m => (?loc :: CallStack) =>
-    Status.Status -> LBS -> ST -> m ()
+    Status.Status -> LBS -> String -> m ()
 shouldBeErr400WithCustomMessage rstStatus rspBody customMessage =
     shouldBeStatusXWithCustomMessages 400 rstStatus rspBody ["\"error\"", customMessage]
 

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -62,6 +62,7 @@ type ThentosConfig' =
   :*> Maybe ("gc_interval"             :> Timeout    :>: "Garbage collection interval")
   :*>       ("log"          :> LogConfig'            :>: "Logging")
   :*>       ("mail"         :> MailConfig'           :>: "Mail templates")
+  :*> Maybe ("a3-prefix"    :> ST                    :>: "URL prefix of the A3 api")
 
 defaultThentosConfig :: ToConfig (ToConfigCode ThentosConfig') Maybe
 defaultThentosConfig =
@@ -80,6 +81,7 @@ defaultThentosConfig =
   :*> NothingO
   :*> Nothing
   :*> Just defaultMailConfig
+  :*> NothingO
 
 type HttpConfig = Tagged (ToConfigCode HttpConfig')
 type HttpConfig' =

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -62,7 +62,7 @@ type ThentosConfig' =
   :*> Maybe ("gc_interval"             :> Timeout    :>: "Garbage collection interval")
   :*>       ("log"          :> LogConfig'            :>: "Logging")
   :*>       ("mail"         :> MailConfig'           :>: "Mail templates")
-  :*> Maybe ("a3-prefix"    :> ST                    :>: "URL prefix of the A3 api")
+  :*>       ("a3-prefix"    :> ST                    :>: "URL prefix of the A3 api")
 
 defaultThentosConfig :: ToConfig (ToConfigCode ThentosConfig') Maybe
 defaultThentosConfig =
@@ -81,7 +81,7 @@ defaultThentosConfig =
   :*> NothingO
   :*> Nothing
   :*> Just defaultMailConfig
-  :*> NothingO
+  :*> Nothing
 
 type HttpConfig = Tagged (ToConfigCode HttpConfig')
 type HttpConfig' =

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -38,7 +38,7 @@ thentosTestConfig = unsafePerformIO . configify . (:[]) . YamlString . cs . unli
     "" :
     ("purescript: " ++ $(getPackageSourceRoot "thentos-purescript") </> "static") :
     "a3-prefix:" :
-    "    "\"http://example.com/\"" :
+    "    http://example.com/" :
     "" :
     "smtp:" :
     "    sender_name: \"Thentos\"" :

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -37,6 +37,8 @@ thentosTestConfig = unsafePerformIO . configify . (:[]) . YamlString . cs . unli
     "    expose_host: \"127.0.0.1\"" :
     "" :
     ("purescript: " ++ $(getPackageSourceRoot "thentos-purescript") </> "static") :
+    "a3-prefix:" :
+    "    "http://example.com/" :
     "" :
     "smtp:" :
     "    sender_name: \"Thentos\"" :

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -38,7 +38,7 @@ thentosTestConfig = unsafePerformIO . configify . (:[]) . YamlString . cs . unli
     "" :
     ("purescript: " ++ $(getPackageSourceRoot "thentos-purescript") </> "static") :
     "a3-prefix:" :
-    "    "http://example.com/" :
+    "    "\"http://example.com/\"" :
     "" :
     "smtp:" :
     "    sender_name: \"Thentos\"" :


### PR DESCRIPTION
Cleaned-up version of #395 .
Notes/questions for the reviewer:

* a3-prefix should clearly not be in thentos-core, since it is specific to `thentos-adhocracy`. I think thentos-adhocracy should work with a `ThentosA3Config` or something, that extends `ThentosConfig` instead of using `ThentosConfig` directly. However, I think making ThentosConfig extensible is probably not trivial enough to put it in this pr (since all the functions dealing with Config are monomorphic).
* In a discussion with @fisx we talked about only storing the path component of a user-path (i.e. not the entire URL) and construct the user resource path dynamically. I don't think this is a good idea anymore, since a3 also stores the user path on user activation, and we probably don't want Thentos' and a3's view of the user path to diverge.