### PR TITLE
Purescript delivery test case.

### DIFF
--- a/thentos-tests/tests/Thentos/Backend/Api/PurescriptSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/PurescriptSpec.hs
@@ -33,11 +33,10 @@ import Test.Hspec.Wai (shouldRespondWith, with, get)
 import qualified Data.ByteString.Lazy as LBS
 
 import Thentos.Action.Core
-
-import qualified Thentos.Backend.Api.Purescript as Purescript
-
 import Thentos.Test.Config
 import Thentos.Test.Core
+
+import qualified Thentos.Backend.Api.Purescript as Purescript
 
 
 tests :: IO ()


### PR DESCRIPTION
This is a minor issue, but it has been asked where the 'honour-it.js' file is coming from, and this patch will make its source go away.  (If you have one in your working copy, please delete by hand once.)