### PR TITLE
Add version annotation for pulp in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ $ sudo apt-get install nodejs npm
 $ mkdir $HOME/opt
 $ cd $HOME/opt
 $ npm install pulp@4.4.1
-$ npm install purescript
+$ npm install purescript@0.7.6
 ```
 
 Then add `$HOME/opt/node_modules/.bin` to your `$PATH`.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ tools installed:
 $ sudo apt-get install nodejs npm
 $ mkdir $HOME/opt
 $ cd $HOME/opt
-$ npm install pulp
+$ npm install pulp@4.4.1
 $ npm install purescript
 ```
 


### PR DESCRIPTION
On ubuntu 14.04 npm tries to install 6.x version of pulp which has rendered my build broken. Pinpointing the version of pulp to 4.4.1 has fixed that.

Edited:
Pinpointing purescript's version is also added.