### PR TITLE
Shrink dependency footprint.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 	path = submodules/servant
 	url = https://github.com/liqd/servant
 	branch = package-servant-session+1
-[submodule "submodules/servant-purescript"]
-	path = submodules/servant-purescript
-	url = https://github.com/liqd/servant-purescript

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,4 @@
 	ignore = dirty
 [submodule "submodules/servant"]
 	path = submodules/servant
-	url = https://github.com/liqd/servant
-	branch = package-servant-session+1
+	url = https://github.com/haskell-servant/servant

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
     directories:
         - $HOME/build/liqd/thentos/.cabal-sandbox
         - $HOME/.cabal
+        - $HOME/.nvm
 
 addons:
     apt:
@@ -37,8 +38,8 @@ before_install:
     - cd ../..
 
 install:
-    - npm install -g pulp@4.4.1
-    - npm install -g purescript@0.7.6
+    - pulp --version || npm install -g pulp@4.4.1
+    - psc  --version || npm install -g purescript@0.7.6
     - travis_retry cabal update
     # We install hlint because we don't want to invalidate i's cache together
     # with the thentos cache

--- a/misc/thentos-install.sh
+++ b/misc/thentos-install.sh
@@ -92,12 +92,12 @@ if [ "$NO_PURESCRIPT" == "" ]; then
 fi
 
 echo -e "\n\nbuilding dependencies...\n" >&2
-cabal install $CABAL_VERBOSITY --dependencies-only -j2 --ghc-options="+RTS -M2G -RTS -w" \
+cabal install $CABAL_VERBOSITY --dependencies-only --ghc-options="+RTS -M2G -RTS -w" \
       --enable-tests --enable-bench --max-backjumps -1 --reorder-goals \
       -fwith-thentos-executable $CABAL_ARGS $SOURCES_STR
 
 echo -e "\n\nbuilding thentos-* packages...\n" >&2
-cabal install $CABAL_VERBOSITY -j2 --ghc-options="+RTS -M2G -RTS -w" \
+cabal install $CABAL_VERBOSITY --ghc-options="+RTS -M2G -RTS -w" \
       --enable-tests --enable-bench --max-backjumps -1 --reorder-goals \
       -fwith-thentos-executable $CABAL_ARGS $SOURCES_STR
 

--- a/misc/thentos-install.sh
+++ b/misc/thentos-install.sh
@@ -22,12 +22,11 @@ SUBMODULE_SOURCES=( servant/servant
                     servant/servant-client
                     servant/servant-docs
                     servant/servant-blaze
-                    servant/servant-session
                     servant/servant-js
                     servant/servant-foreign
                     pronk
                   )
-SOURCES=( thentos-core thentos-tests thentos-adhocracy )
+SOURCES=( servant-session thentos-core thentos-tests thentos-adhocracy )
 ALL_SOURCES=( "${SUBMODULE_SOURCES[@]}" "${SOURCES[@]}" )
 SOURCES_STR=$( IFS=$' ', echo ${SOURCES[*]} )
 

--- a/misc/thentos-install.sh
+++ b/misc/thentos-install.sh
@@ -25,7 +25,6 @@ SUBMODULE_SOURCES=( servant/servant
                     servant/servant-session
                     servant/servant-js
                     servant/servant-foreign
-                    servant-purescript
                     pronk
                   )
 SOURCES=( thentos-core thentos-tests thentos-adhocracy )

--- a/servant-session/CHANGELOG.md
+++ b/servant-session/CHANGELOG.md
@@ -1,0 +1,4 @@
+HEAD
+----
+
+* experimental version

--- a/servant-session/LICENSE
+++ b/servant-session/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2014, Zalora South East Asia Pte Ltd
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Zalora South East Asia Pte Ltd nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/servant-session/README.md
+++ b/servant-session/README.md
@@ -1,0 +1,13 @@
+# servant-session
+
+![servant](https://raw.githubusercontent.com/haskell-servant/servant/master/servant.png)
+
+
+**status: EXPERIMENTAL**
+
+(documentation coming up)
+
+
+## Getting started
+
+We've written a [tutorial](http://haskell-servant.github.io/tutorial/) guide that introduces the core types and features of servant. After this article, you should be able to write your first servant webservices, learning the rest from the haddocks' examples.

--- a/servant-session/Setup.hs
+++ b/servant-session/Setup.hs
@@ -1,0 +1,2 @@
+import           Distribution.Simple
+main = defaultMain

--- a/servant-session/servant-session.cabal
+++ b/servant-session/servant-session.cabal
@@ -1,0 +1,77 @@
+name:                servant-session
+version:             0.5
+synopsis:            A wai middleware and servant combinator for maintaining session state.
+description:
+  A wai middleware and servant combinator for maintaining session state.
+  .
+  You can learn about the basics in the <http://haskell-servant.github.io/tutorial tutorial>.
+homepage:            http://haskell-servant.github.io/
+Bug-reports:         http://github.com/haskell-servant/servant/issues
+license:             BSD3
+license-file:        LICENSE
+author:              Matthias Fischmann, Julian K. Arni
+maintainer:          matthias.fischmann@liqd.net
+copyright:           2015 liquid democracy e.V., Germany
+category:            Web
+build-type:          Simple
+cabal-version:       >=1.10
+tested-with:         GHC >= 7.8
+extra-source-files:
+  CHANGELOG.md
+  README.md
+bug-reports:         http://github.com/haskell-servant/servant/issues
+source-repository head
+  type: git
+  location: http://github.com/haskell-servant/servant.git
+
+
+library
+  exposed-modules:
+    Servant.Session
+  build-depends:
+        base               >= 4.7  && < 5
+      , bytestring         >= 0.10 && < 0.11
+      , blaze-builder      >= 0.4  && < 0.5
+      , http-types         >= 0.8  && < 0.9
+      , servant            == 0.5.*
+      , servant-server     == 0.5.*
+      , wai                >= 3.0  && < 3.1
+      , random             >= 1.1  && < 1.2
+      , cookie             >= 0.4  && < 0.5
+      , uuid               >= 1.3  && < 1.4
+      , clientsession      >= 0.9  && < 0.10
+      , vault
+      , wai-session
+  hs-source-dirs: src
+  default-language: Haskell2010
+  ghc-options: -Wall
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  ghc-options:
+    -Wall -fno-warn-name-shadowing
+  default-language: Haskell2010
+  hs-source-dirs: test
+  main-is: Spec.hs
+  other-modules:
+      Servant.SessionSpec
+  build-depends:
+      base == 4.*
+    , aeson
+    , cookie
+    , bytestring
+    , clientsession
+    , containers
+    , hspec == 2.*
+    , hspec-wai
+    , http-types
+    , servant-server
+    , servant-session
+    , string-conversions
+    , text
+    , time
+    , wai
+    , wai-extra
+    , wai-session
+    , transformers
+    , vault

--- a/servant-session/src/Servant/Session.hs
+++ b/servant-session/src/Servant/Session.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+
+module Servant.Session (SSession) where
+
+import           Data.Proxy                      (Proxy (Proxy))
+import qualified Data.Vault.Lazy                 as Vault
+import           Network.Wai                     (vault)
+import           Network.Wai.Session             (Session)
+import           Servant.API                     ((:>))
+import           Servant.Server.Internal         (HasServer, ServerT, route, passToServer)
+import           Servant.Server.Internal.Router  (Router'(WithRequest))
+
+
+-- | @SSession m k v@ represents a session storage with keys of type @k@,
+-- values of type @v@, and operating under the monad @m@.
+-- The underlying implementation uses the 'wai-session' package, and any
+-- backend compatible with that package should work here too.
+data SSession (m :: * -> *) (k :: *) (v :: *)
+
+-- | 'HasServer' instance for 'SSession'.
+instance (HasServer sublayout) => HasServer (SSession n k v :> sublayout) where
+  type ServerT (SSession n k v :> sublayout) m
+    = (Vault.Key (Session n k v) -> Maybe (Session n k v)) -> ServerT sublayout m
+  route Proxy a = WithRequest $ \request -> route (Proxy :: Proxy sublayout)
+        $ passToServer a (\key -> Vault.lookup key $ vault request)

--- a/servant-session/test/Servant/SessionSpec.hs
+++ b/servant-session/test/Servant/SessionSpec.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeOperators         #-}
+
+{-# OPTIONS -fno-warn-incomplete-patterns #-}
+
+module Servant.SessionSpec (spec) where
+
+import           Control.Monad              (replicateM_)
+import           Control.Monad.Trans.Except (ExceptT)
+import qualified Data.Vault.Lazy            as Vault
+import           Network.HTTP.Types         (methodGet)
+import           Network.Wai                (Middleware, Application)
+import           Network.Wai.Session        (SessionStore, Session, withSession)
+import           Network.Wai.Session.Map    (mapStore)
+import           Network.Wai.Test           (simpleBody, simpleHeaders)
+import           Servant                    (Proxy(Proxy), ServantErr, Get, JSON, (:>), serve)
+import           Test.Hspec                 (Spec, context, describe, it, shouldBe, shouldSatisfy)
+import           Test.Hspec.Wai             (with, request, liftIO)
+import           Web.Cookie                 (SetCookie, def, parseSetCookie,
+                                             setCookieName, setCookieValue, setCookieMaxAge)
+
+import           Servant.Session
+
+
+spec :: Spec
+spec = describe "Servant.Session" . with server $ do
+
+  context "the cookie is set" $ do
+
+    it "has read and write access to the cookie" $ do
+        replicateM_ 5 $ request methodGet "" [("Cookie", "test=const")] ""
+        x <- request methodGet "" [("Cookie", "test=const")] ""
+        liftIO $ simpleBody x `shouldSatisfy` (== "\"4\"")
+
+
+  context "no cookie is set" $ do
+
+    it "one will be in the Set-Cookie header of the response" $ do
+        resp <- request methodGet "" [] ""
+        let Just c = parseSetCookie <$> lookup "Set-Cookie" (simpleHeaders resp)
+        liftIO $ setCookieName c `shouldBe` setCookieName setCookieOpts
+        liftIO $ setCookieValue c `shouldBe` "const"
+
+    it "adds SetCookie params" $ do
+        resp <- request methodGet "" [] ""
+        let Just c = parseSetCookie <$> lookup "Set-Cookie" (simpleHeaders resp)
+        liftIO $ setCookieMaxAge c `shouldBe` setCookieMaxAge setCookieOpts
+
+
+type API = SSession IO Int Int :> Get '[JSON] String
+
+setCookieOpts :: SetCookie
+setCookieOpts = def { setCookieName = "test", setCookieMaxAge = Just 300 }
+
+sessionMiddleware :: SessionStore IO Int a -> Vault.Key (Session IO Int a) -> Middleware
+sessionMiddleware s = withSession s "test" setCookieOpts
+
+server :: IO Application
+server = do
+    ref <- mapStore (return "const")
+    key <- Vault.newKey
+    return $ sessionMiddleware ref key
+           $ serve (Proxy :: Proxy API) (handler key)
+
+handler :: Vault.Key (Session IO Int Int)
+        -> (Vault.Key (Session IO Int Int) -> Maybe (Session IO Int Int))
+        -> ExceptT ServantErr IO String
+handler key smap = do
+    x <- liftIO $ lkup 1
+    case x of
+        Nothing -> liftIO (ins 1 0) >> return "Nothing"
+        Just y -> liftIO (ins 1 $ succ y) >> return (show y)
+  where
+    Just (lkup, ins) = smap key

--- a/servant-session/test/Spec.hs
+++ b/servant-session/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/thentos-adhocracy/thentos-adhocracy.cabal
+++ b/thentos-adhocracy/thentos-adhocracy.cabal
@@ -46,7 +46,7 @@ library
     , aeson-pretty >=0.7.2 && <0.8
     , base >=4.8.1.0 && <5
     , case-insensitive >=1.2.0.4 && <1.3
-    , configifier >=0.0.7 && <0.1
+    , configifier >=0.0.8 && <0.1
     , functor-infix >=0.0.3 && <0.1
     , hslogger >=1.2.9 && <1.3
     , http-client >=0.4.22 && <0.5
@@ -112,7 +112,7 @@ test-suite tests
     , base >=4.8.1.0 && <5
     , bytestring >=0.10.6.0 && <0.11
     , case-insensitive >=1.2.0.4 && <1.3
-    , configifier >=0.0.7 && <0.1
+    , configifier >=0.0.8 && <0.1
     , containers >=0.5.6.2 && <0.6
     , hspec >=2.1.10 && <2.3
     , hspec-wai >=0.6.3 && <0.7

--- a/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
@@ -178,7 +178,6 @@ hackTogetherSomeReasonableOrder (Docs.API intros endpoints) = Docs.API (f <$> so
 --
 -- cleanup steps:
 --
--- - move servant-session from servant repo to liqd/servant-session (just for now)
 -- - update servant submodule to top of master and use pretty-printing docs from there
 
 prettyMimeRender' :: Map MediaType (LBS -> LBS) -> Docs.API -> Docs.API

--- a/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
@@ -54,7 +54,7 @@ import qualified Data.Map as Map
 import qualified Data.Text as ST
 import qualified Servant.Docs as Docs
 import qualified Servant.Docs.Internal as Docs
-import qualified Servant.Foreign as Foreign
+import qualified Servant.Foreign as F
 import qualified Servant.JS as JS
 
 import Thentos.Backend.Api.Auth
@@ -87,9 +87,9 @@ instance ToSample ST where
     toSamples _ = [("empty", "")]
 
 -- | the 'Raw' endpoint has 'Foreign', but it is @Method -> Req@, which doesn't have a
--- 'GenerateList' instance.  so, there.  you got one, type checker.  and since @Foreign.Method@ is
+-- 'GenerateList' instance.  so, there.  you got one, type checker.  and since @F.Method@ is
 -- not exported, we keep it polymorphic.
-instance {-# OVERLAPPABLE #-} JS.GenerateList (a -> Foreign.Req) where
+instance {-# OVERLAPPABLE #-} JS.GenerateList (a -> F.Req) where
     generateList _ = []
 
 class HasDocs api => HasDocExtras api where
@@ -106,7 +106,7 @@ class HasDocs api => HasDocExtras api where
 
 type HasFullDocExtras api =
     ( HasDocs (RestDocs api), HasDocExtras (RestDocs api)
-    , Foreign.HasForeign api, JS.GenerateList (Foreign.Foreign api)
+    , F.HasForeign F.NoTypes api, JS.GenerateList (F.Foreign api)
     )
 
 restDocs :: forall api m. (Monad m, HasFullDocExtras api)
@@ -117,8 +117,8 @@ restDocs _ proxy =
    :<|> pure (restDocsNg proxy)
 
 
-restDocsMd :: forall api. (HasDocExtras (RestDocs api), Foreign.HasForeign api
-      , JS.GenerateList (Foreign.Foreign api))
+restDocsMd :: forall api. ( HasDocExtras (RestDocs api), F.HasForeign F.NoTypes api
+                          , JS.GenerateList (F.Foreign api))
          => Proxy (RestDocs api) -> Docs.API
 restDocsMd proxy = prettyMimeRender . hackTogetherSomeReasonableOrder $
         Docs.docsWith

--- a/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
@@ -35,7 +35,7 @@ import Data.Map (Map)
 import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy(Proxy))
 import Data.String.Conversions (ST, LBS, SBS, cs, (<>))
-import Data.Version (Version)
+import Data.Version (Version, showVersion)
 import Data.Void (Void)
 import Network.HTTP.Media (MediaType)
 import Safe (fromJustNote)
@@ -125,7 +125,11 @@ restDocsMd proxy = hackTogetherSomeReasonableOrder $
             intros unsafeCoerceGetExtraInfo (pretty (Proxy :: Proxy api))
       where
         intros :: [Docs.DocIntro]
-        intros = Docs.DocIntro ("@@0.0@@" ++ getTitle proxy) [show $ getCabalPackageVersion proxy]
+        intros = Docs.DocIntro ("@@0.0@@" ++ getTitle proxy)
+                   [ ("package: " <> cs (getCabalPackageName proxy)) <>
+                     (case showVersion (getCabalPackageVersion proxy) of
+                         "" -> " (no version info)"
+                         v -> " (version: " <> v <> ")") ]
                : getIntros proxy
 
         unsafeCoerceGetExtraInfo :: forall api'. Docs.ExtraInfo api'

--- a/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Docs/Common.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE ScopedTypeVariables                      #-}
 {-# LANGUAGE TypeOperators                            #-}
 {-# LANGUAGE UndecidableInstances                     #-}
-{-# LANGUAGE ViewPatterns                             #-}
 
 {-# OPTIONS -fno-warn-orphans #-}
 
@@ -28,16 +27,11 @@ import Control.Arrow (second)
 import Control.Concurrent.MVar (newMVar)
 import Control.Lens ((&), (%~), (.~))
 import "cryptonite" Crypto.Random (drgNew)
-import Data.Aeson.Encode.Pretty (encodePretty', defConfig, Config(confCompare))
-import Data.Aeson.Utils (decodeV)
 import Data.List (sort)
-import Data.Map (Map)
-import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy(Proxy))
-import Data.String.Conversions (ST, LBS, SBS, cs, (<>))
+import Data.String.Conversions (ST, SBS, cs, (<>))
 import Data.Version (Version, showVersion)
 import Data.Void (Void)
-import Network.HTTP.Media (MediaType)
 import Safe (fromJustNote)
 import Servant.API (Capture, (:>), Post, Get, (:<|>)((:<|>)), MimeRender(mimeRender))
 import Servant.API.Capture ()
@@ -49,9 +43,6 @@ import Servant.Docs (ToCapture(..), DocCapture(DocCapture), ToSample(toSamples),
 import Servant.Server (ServerT)
 import System.IO.Unsafe (unsafePerformIO)
 
-import qualified Data.Aeson as Aeson
-import qualified Data.HashMap.Strict as HM
-import qualified Data.Map as Map
 import qualified Data.Text as ST
 import qualified Servant.Docs as Docs
 import qualified Servant.Docs.Internal as Docs

--- a/thentos-core/src/Thentos/Backend/Api/Docs/Proxy.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Docs/Proxy.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds                                #-}
+{-# LANGUAGE FlexibleContexts                         #-}
 {-# LANGUAGE FlexibleInstances                        #-}
+{-# LANGUAGE MultiParamTypeClasses                    #-}
 {-# LANGUAGE OverloadedStrings                        #-}
 {-# LANGUAGE ScopedTypeVariables                      #-}
 {-# LANGUAGE TypeFamilies                             #-}
@@ -15,7 +17,7 @@ import Servant.API ((:<|>))
 import Servant.Docs (HasDocs(..))
 
 import qualified Servant.Docs as Docs
-import qualified Servant.Foreign as Foreign
+import qualified Servant.Foreign as F
 
 import Thentos.Backend.Api.Docs.Common ()
 import Thentos.Backend.Api.Proxy (ServiceProxy)
@@ -36,7 +38,7 @@ instance HasDocs sublayout => HasDocs (sublayout :<|> ServiceProxy) where
                , "service are returned unmodified."
                ]
 
-instance Foreign.HasForeign ServiceProxy where
-    type Foreign ServiceProxy = Foreign.Req
-    foreignFor Proxy req =
-        req & Foreign.funcName  %~ ("ServiceProxy" :)
+instance F.HasForeign F.NoTypes ServiceProxy where
+    type Foreign ServiceProxy = F.Req
+    foreignFor Proxy Proxy req =
+        req & F.funcName %~ ("ServiceProxy" :)

--- a/thentos-core/src/Thentos/Backend/Api/Simple.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Simple.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds                                #-}
+{-# LANGUAGE FlexibleContexts                         #-}
 {-# LANGUAGE FlexibleInstances                        #-}
+{-# LANGUAGE MultiParamTypeClasses                    #-}
 {-# LANGUAGE OverloadedStrings                        #-}
 {-# LANGUAGE ScopedTypeVariables                      #-}
 {-# LANGUAGE TypeFamilies                             #-}
@@ -22,7 +24,7 @@ import Servant.API.ResponseHeaders (Headers, addHeader)
 import System.Log.Logger (Priority(INFO))
 
 import qualified Servant.Docs as Docs
-import qualified Servant.Foreign as Foreign
+import qualified Servant.Foreign as F
 
 import System.Log.Missing (logger)
 import Thentos.Action
@@ -192,32 +194,31 @@ instance HasDocExtras (RestDocs Api) where
 --
 -- we more / less restrictive instances.  We should merge servant master in our submodule branch,
 -- though.
-instance {-# OVERLAPPABLE #-} Foreign.HasForeign (Post200 b a) where
-    type Foreign (Post200 b a) = Foreign.Req
-    foreignFor Proxy req =
-        req & Foreign.funcName  %~ ("post200" :)
-            & Foreign.reqMethod .~ "POST"
+instance {-# OVERLAPPABLE #-} F.HasForeign F.NoTypes (Post200 b a) where
+    type Foreign (Post200 b a) = F.Req
+    foreignFor Proxy Proxy req =
+        req & F.funcName  %~ ("post200" :)
+            & F.reqMethod .~ "POST"
 
-instance {-# OVERLAPPING #-} Foreign.HasForeign (Post '[PNG] a) where
-    type Foreign (Post '[PNG] a) = Foreign.Req
-    foreignFor Proxy req =
-        req & Foreign.funcName  %~ ("post" :)
-            & Foreign.reqMethod .~ "POST"
+instance {-# OVERLAPPING #-} F.HasForeign F.NoTypes (Post '[PNG] a) where
+    type Foreign (Post '[PNG] a) = F.Req
+    foreignFor Proxy Proxy req =
+        req & F.funcName  %~ ("post" :)
+            & F.reqMethod .~ "POST"
 
-instance {-# OVERLAPPING #-} Foreign.HasForeign (Post '[WAV] a) where
-    type Foreign (Post '[WAV] a) = Foreign.Req
-    foreignFor Proxy req =
-        req & Foreign.funcName  %~ ("post" :)
-            & Foreign.reqMethod .~ "POST"
+instance {-# OVERLAPPING #-} F.HasForeign F.NoTypes (Post '[WAV] a) where
+    type Foreign (Post '[WAV] a) = F.Req
+    foreignFor Proxy Proxy req =
+        req & F.funcName  %~ ("post" :)
+            & F.reqMethod .~ "POST"
 
 -- FIXME: move this to module "Auth".
-instance Foreign.HasForeign sub => Foreign.HasForeign (ThentosAuth :> sub) where
-    type Foreign (ThentosAuth :> sub) = Foreign.Foreign sub
-    foreignFor Proxy req = Foreign.foreignFor (Proxy :: Proxy sub) $ req
-            & Foreign.reqHeaders <>~
-                [Foreign.HeaderArg . cs . foldedCase $
-                    renderThentosHeaderName ThentosHeaderSession]
+instance F.HasForeign F.NoTypes sub => F.HasForeign F.NoTypes (ThentosAuth :> sub) where
+    type Foreign (ThentosAuth :> sub) = F.Foreign sub
+    foreignFor plang Proxy req = F.foreignFor plang (Proxy :: Proxy sub) $ req
+            & F.reqHeaders <>~
+                [F.HeaderArg (cs . foldedCase $ renderThentosHeaderName ThentosHeaderSession, "")]
 
-instance Foreign.HasForeign sub => Foreign.HasForeign (ThentosAssertHeaders :> sub) where
-    type Foreign (ThentosAssertHeaders :> sub) = Foreign.Foreign sub
-    foreignFor Proxy = Foreign.foreignFor (Proxy :: Proxy sub)
+instance F.HasForeign F.NoTypes sub => F.HasForeign F.NoTypes (ThentosAssertHeaders :> sub) where
+    type Foreign (ThentosAssertHeaders :> sub) = F.Foreign sub
+    foreignFor plang Proxy = F.foreignFor plang (Proxy :: Proxy sub)

--- a/thentos-core/src/Thentos/Backend/Api/Simple.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Simple.hs
@@ -12,7 +12,6 @@
 module Thentos.Backend.Api.Simple where
 
 import Control.Lens ((^.), (&), (<>~), (%~), (.~))
-import Data.CaseInsensitive (foldedCase)
 import Data.Proxy (Proxy(Proxy))
 import Data.String.Conversions (ST, SBS, cs)
 import Data.Void (Void)
@@ -211,13 +210,6 @@ instance {-# OVERLAPPING #-} F.HasForeign F.NoTypes (Post '[WAV] a) where
     foreignFor Proxy Proxy req =
         req & F.funcName  %~ ("post" :)
             & F.reqMethod .~ "POST"
-
--- FIXME: move this to module "Auth".
-instance F.HasForeign F.NoTypes sub => F.HasForeign F.NoTypes (ThentosAuth :> sub) where
-    type Foreign (ThentosAuth :> sub) = F.Foreign sub
-    foreignFor plang Proxy req = F.foreignFor plang (Proxy :: Proxy sub) $ req
-            & F.reqHeaders <>~
-                [F.HeaderArg (cs . foldedCase $ renderThentosHeaderName ThentosHeaderSession, "")]
 
 instance F.HasForeign F.NoTypes sub => F.HasForeign F.NoTypes (ThentosAssertHeaders :> sub) where
     type Foreign (ThentosAssertHeaders :> sub) = F.Foreign sub

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -101,7 +101,7 @@ library
     , bytestring-conversion >=0.3.1 && <0.4
     , case-insensitive >=1.2.0.4 && <1.3
     , cond >=0.4 && <0.5
-    , configifier >=0.0.7 && <0.1
+    , configifier >=0.0.8 && <0.1
     , containers >=0.5.6.2 && <0.6
     , cookie >=0.4.1 && <0.5
     , cryptonite >=0.6 && <0.8

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -150,7 +150,6 @@ library
     , servant-docs ==0.5
     , servant-foreign ==0.5
     , servant-js ==0.5
-    , servant-purescript ==0.1
     , servant-server ==0.5
     , servant-session ==0.5
     , string-conversions >=0.4 && <0.5

--- a/thentos-tests/thentos-tests.cabal
+++ b/thentos-tests/thentos-tests.cabal
@@ -48,7 +48,7 @@ library
     , base >=4.8.1.0 && <5
     , bytestring >=0.10.6.0 && <0.11
     , case-insensitive >=1.2.0.4 && <1.3
-    , configifier >=0.0.7 && <0.1
+    , configifier >=0.0.8 && <0.1
     , containers >=0.5.6.2 && <0.6
     , cryptonite >=0.6 && <0.8
     , filepath >=1.4.0.0 && <1.5
@@ -103,7 +103,7 @@ test-suite tests
     , blaze-html
     , bytestring
     , case-insensitive >=1
-    , configifier >=0.0.7 && <0.1
+    , configifier >=0.0.8 && <0.1
     , containers >=0.5.6.2 && <0.6
     , cookie >=0.4.1.6 && <4.2
     , digestive-functors
@@ -160,7 +160,7 @@ benchmark load-test
       aeson >=0.8.0.2 && <0.9
     , base >=4.8.1.0 && <5
     , bytestring >=0.10.6.0 && <0.11
-    , configifier >=0.0.7 && <0.1
+    , configifier >=0.0.8 && <0.1
     , functor-infix >=0.0.3 && <0.1
     , http-conduit >=2.1.8 && <2.2
     , http-types >=0.8.6 && <0.9


### PR DESCRIPTION
After this goes to master, after the next update, all previously cloned repos may need to do this:

```
rm -rf .git/modules/submodules/servant-purescript
rm -rf .git/modules/submodules/servant
cabal sandbox delete-source .../submodules/servant/servant-session
./misc/thentos-install.sh
```
