### PR TITLE
Arguments to Crypto.BCrypt.validatePassword where flipped

### DIFF
--- a/thentos-core/src/Thentos/Util.hs
+++ b/thentos-core/src/Thentos/Util.hs
@@ -62,7 +62,7 @@ bad = ("incorrect", "$2a$10$KLJDd7d6VCKSIPcDA3QHGu9tYpfnOTSvgueXu/JmwlxfWY4fDOAl
 mainTest :: (SBS, SBS) -> IO ()
 mainTest (m, c) = do
   ms <- allEncodings m
-  let valid = or $ (`Crypto.BCrypt.validatePassword` c) <$> ms
+  let valid = or $ (Crypto.BCrypt.validatePassword c) <$> ms
   print valid
 
 -- come up with as many encodings as i could think of.  one of them should be the one used in


### PR DESCRIPTION
Additional comments:

* For ASCII password no further encoding is necessary, having additional test cases with non-ASCII would help going further.
* Make sure to depend on memory>=0.10 (https://github.com/A1kmm/hs-bcrypt/issues/8 https://github.com/vincenthz/hs-memory/commit/17af888d3a34c2322a17b8556f45150c16a98fde)