### PR TITLE
Path handling (across different dev and op scenarios)

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -19,4 +19,4 @@ cp -r travis-cache/data ./hlint/.cabal-sandbox/share/x86_64-linux-ghc-7.8.4/hlin
 sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
 
 cabal update
-./misc/thentos-install.hs -c "--force-reinstalls" -t
+./misc/thentos-install.hs -c "--force-reinstalls" -t -p

--- a/thentos-adhocracy/devel.config
+++ b/thentos-adhocracy/devel.config
@@ -51,6 +51,7 @@ gc_interval: 30m
 log:
     path: ./log/thentos.log
     level: DEBUG
+    stdout: True
 
 database:
     name: "thentosdev"

--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Backend/Api/Simple.hs
@@ -75,7 +75,7 @@ import Thentos.Config
 import Thentos.Ends.Types (PNG, WAV)
 import Thentos.Types
 
-import qualified Paths_thentos_adhocracy__ as Paths
+import qualified Paths_thentos_adhocracy__ as Paths (version)
 import qualified Thentos.Action as A
 import qualified Thentos.Action.Types as AC
 import qualified Thentos.Backend.Api.PureScript

--- a/thentos-adhocracy/tests/Thentos/Adhocracy3/Backend/Api/SimpleSpec.hs
+++ b/thentos-adhocracy/tests/Thentos/Adhocracy3/Backend/Api/SimpleSpec.hs
@@ -243,11 +243,11 @@ spec =
   where
     setupBackend :: IO Application
     setupBackend = do
-        as@(ActionState cfg _ connPool) <- createActionState "test_thentosa3" thentosTestConfig
+        as@(ActionState cfg _ connPool) <- createActionState
         mgr <- newManager defaultManagerSettings
         withResource connPool createGod
         ((), ()) <- runActionWithPrivs [toCNF RoleAdmin] () as $
-              autocreateMissingServices thentosTestConfig
+              autocreateMissingServices cfg
         let Just beConfig = Tagged <$> cfg >>. (Proxy :: Proxy '["backend"])
         return $! serveApi mgr beConfig as
 

--- a/thentos-adhocracy/thentos-adhocracy.cabal
+++ b/thentos-adhocracy/thentos-adhocracy.cabal
@@ -117,6 +117,7 @@ test-suite tests
     , case-insensitive >=1.2.0.4 && <1.3
     , configifier >=0.0.8 && <0.1
     , containers >=0.5.6.2 && <0.6
+    , filepath >=1.4.0.0 && <1.5
     , hspec >=2.1.10 && <2.3
     , hspec-wai >=0.6.3 && <0.7
     , HTTP >=4000.2.20 && <4000.3

--- a/thentos-core/devel.config
+++ b/thentos-core/devel.config
@@ -30,6 +30,7 @@ gc_interval: 30m
 log:
     path: ./log/thentos.log
     level: DEBUG
+    stdout: True
 
 database:
     name: "thentosdev"

--- a/thentos-core/exec/Captcha.hs
+++ b/thentos-core/exec/Captcha.hs
@@ -24,7 +24,7 @@ main :: IO ()
 main = do
     config :: ThentosConfig <- getConfig "devel.config"
     checkEspeak  -- Make sure that we can successfully generate audio captchas
-    connPool <- createConnPoolAndInitDb $ config >>. (Proxy :: Proxy '["database", "name"])
+    connPool <- createConnPoolAndInitDb config
     actionState <- makeActionState config connPool
     _ <- runGcLoop actionState $ config >>. (Proxy :: Proxy '["gc_interval"])
 

--- a/thentos-core/exec/Captcha.hs
+++ b/thentos-core/exec/Captcha.hs
@@ -26,7 +26,6 @@ main = do
     checkEspeak  -- Make sure that we can successfully generate audio captchas
     connPool <- createConnPoolAndInitDb $ config >>. (Proxy :: Proxy '["database", "name"])
     actionState <- makeActionState config connPool
-    configLogger . Tagged $ config >>. (Proxy :: Proxy '["log"])
     _ <- runGcLoop actionState $ config >>. (Proxy :: Proxy '["gc_interval"])
 
     let backendCfg  = forceCfg "backend" $ Tagged <$> config >>. (Proxy :: Proxy '["backend"])

--- a/thentos-core/src/Thentos/Backend/Api/Captcha.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Captcha.hs
@@ -43,7 +43,7 @@ import Thentos.Config
 import Thentos.Ends.Types
 import Thentos.Types
 
-import qualified Paths_thentos_core__ as Paths
+import qualified Paths_thentos_core__ as Paths (version)
 
 
 -- * main for frontend interface (called from browsers to generate captchas)

--- a/thentos-core/src/Thentos/Backend/Api/Simple.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Simple.hs
@@ -34,7 +34,7 @@ import Thentos.Config
 import Thentos.Ends.Types
 import Thentos.Types
 
-import qualified Paths_thentos_core__ as Paths
+import qualified Paths_thentos_core__ as Paths (version)
 import qualified Thentos.Backend.Api.PureScript as Purs
 
 

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -25,7 +25,7 @@ import System.FilePath (takeDirectory)
 import System.IO (stdout)
 import System.Log.Formatter (simpleLogFormatter, nullFormatter)
 import System.Log.Handler.Simple (formatter, fileHandler, streamHandler)
-import System.Log.Logger (Priority(DEBUG, CRITICAL), removeAllHandlers, updateGlobalLogger,
+import System.Log.Logger (Priority(DEBUG, INFO, CRITICAL), removeAllHandlers, updateGlobalLogger,
                           setLevel, setHandlers)
 import System.Log.Missing (loggerName, logger, Prio(..))
 import Text.Show.Pretty (ppShow)

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -26,6 +26,7 @@ module Thentos.Config
     , extractTargetUrl
     , getDefaultUser
     , buildEmailAddress
+    , signupLogger
     )
 where
 

--- a/thentos-core/src/Thentos/Sybil/GraphicCaptcha.hs
+++ b/thentos-core/src/Thentos/Sybil/GraphicCaptcha.hs
@@ -21,7 +21,6 @@ import Graphics.Rasterific.Texture (uniformTexture, patternTexture, transformTex
 import Graphics.Rasterific.Transformations (translate)
 import Graphics.Text.TrueType (Font, loadFontFile)
 
-import Paths_thentos_core__
 import Thentos.Types
 
 
@@ -29,7 +28,7 @@ import Thentos.Types
 -- solution to the captcha.
 generateCaptcha :: Random20 -> IO (ImageData, ST)
 generateCaptcha rnd = do
-    fontPath <- getDataFileName "resources/fonts/Courier_Prime_Bold.ttf"
+    let fontPath = "./resources/fonts/Courier_Prime_Bold.ttf"
     font <- loadFontFile fontPath >>= either (throwIO . ErrorCall) return
     let random20ToStdGen = mkStdGen . sum . map ord . cs . fromRandom20
     return $ flip evalRand (random20ToStdGen rnd) $ do

--- a/thentos-core/src/Thentos/Transaction/Core.hs
+++ b/thentos-core/src/Thentos/Transaction/Core.hs
@@ -1,5 +1,6 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 module Thentos.Transaction.Core
     ( ThentosQuery
@@ -16,13 +17,13 @@ module Thentos.Transaction.Core
     )
 where
 
-import Control.Monad.Except (throwError)
 import Control.Exception.Lifted (catch, throwIO)
-import Control.Monad (void, liftM)
+import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT, runReaderT, ask)
-import Control.Monad.Trans.Either (EitherT, runEitherT)
 import Control.Monad.Trans.Control (MonadBaseControl)
+import Control.Monad.Trans.Either (EitherT, runEitherT)
+import Control.Monad (void, liftM)
 import Data.Int (Int64)
 import Data.String (fromString)
 import Database.PostgreSQL.Simple (Connection, SqlError, ToRow, FromRow, Query, query, execute,

--- a/thentos-core/src/Thentos/Transaction/Core.hs
+++ b/thentos-core/src/Thentos/Transaction/Core.hs
@@ -33,22 +33,21 @@ import Database.PostgreSQL.Simple.ToField (ToField(toField))
 import Database.PostgreSQL.Simple.Transaction (withTransaction)
 import Database.PostgreSQL.Simple.Types (Default(Default))
 
-import Paths_thentos_core__
 import Thentos.Types
 
 
 type ThentosQuery e a = EitherT (ThentosError e) (ReaderT Connection IO) a
 
-schemaFile :: IO FilePath
-schemaFile = getDataFileName "schema/schema.sql"
+schemaFile :: FilePath
+schemaFile = "./schema/schema.sql"
 
-wipeFile :: IO FilePath
-wipeFile = getDataFileName "schema/wipe.sql"
+wipeFile :: FilePath
+wipeFile = "./schema/wipe.sql"
 
 -- | Creates the database schema if it does not already exist.
 createDB :: Connection -> IO ()
 createDB conn = do
-    schema <- readFile =<< schemaFile
+    schema <- readFile schemaFile
     void $ execute_ conn (fromString schema)
 
 -- | Execute a 'ThentosQuery'. Every query is a DB transaction, so the DB state won't change

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -102,7 +102,7 @@ thentosTestConfigYaml = YamlString . cs . unlines $
     "    path: /dev/null" :
     "    level: EMERGENCY" :
     "    stdout: False" :
-        -- (override this in individual test cases or use 'withLogger')
+        -- (change this to your like during debugging)
     "" :
     "database:" :
     "    name: unused" :

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -103,8 +103,6 @@ thentosTestConfigYaml = YamlString . cs . unlines $
     "    level: EMERGENCY" :
         -- (override this in individual test cases or use 'withLogger')
     "" :
-    "signup_log: signups.log" :
-    "" :
     "database:" :
     "    name: unused" :
     "" :

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -4,6 +4,16 @@
 {-# LANGUAGE TypeOperators     #-}
 
 module Thentos.Test.Config
+    ( thentosTestConfig
+    , thentosTestConfig'
+    , thentosTestConfigSources
+    , thentosTestConfigYaml
+    , godUid
+    , godName
+    , godPass
+    , createGod
+    , forceUserEmail
+    )
 where
 
 import Control.Concurrent.MVar (MVar, readMVar, newMVar)
@@ -35,7 +45,13 @@ memoizeCurrentDirectoryState = unsafePerformIO $ getCurrentDirectory >>= newMVar
 
 
 thentosTestConfig :: IO ThentosConfig
-thentosTestConfig = memoizeCurrentDirectory >> thentosTestConfigSources >>= getConfigWithSources
+thentosTestConfig = thentosTestConfig' []
+
+thentosTestConfig' :: [Source] -> IO ThentosConfig
+thentosTestConfig' extra =
+    memoizeCurrentDirectory >>
+    thentosTestConfigSources >>=
+    getConfigWithSources . (++ extra)
 
 thentosTestConfigSources :: IO [Source]
 thentosTestConfigSources = do

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -27,6 +27,7 @@ mkThentosTestConfig = unsafePerformIO . configify
 
 thentosTestConfigYaml :: Source
 thentosTestConfigYaml = YamlString . cs . unlines $
+    "root_path: ." :
     "backend:" :
     "    bind_port: 7118" :
     "    bind_host: \"127.0.0.1\"" :

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -30,10 +30,10 @@ thentosTestConfigSources :: IO [Source]
 thentosTestConfigSources = do
     e <- getEnvironment
     a <- getArgs
-    return [thentosTestConfigYaml', ShellEnv e, CommandLine a]
+    return [thentosTestConfigYaml, ShellEnv e, CommandLine a]
 
-thentosTestConfigYaml' :: Source
-thentosTestConfigYaml' = YamlString . cs . unlines $
+thentosTestConfigYaml :: Source
+thentosTestConfigYaml = YamlString . cs . unlines $
     "root_path: ." :
     "" :
     "backend:" :

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -101,6 +101,7 @@ thentosTestConfigYaml = YamlString . cs . unlines $
     "log:" :
     "    path: /dev/null" :
     "    level: EMERGENCY" :
+    "    stdout: False" :
         -- (override this in individual test cases or use 'withLogger')
     "" :
     "database:" :

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -9,7 +9,7 @@ where
 import Database.PostgreSQL.Simple (Connection)
 import Data.Configifier
     ( (:*>)((:*>)), Id(Id), Tagged(Tagged), MaybeO(JustO)
-    , Source(YamlString, ShellEnv, CommandLine), configify
+    , Source(YamlString, ShellEnv, CommandLine)
     )
 import Data.Maybe (fromMaybe)
 import Data.String.Conversions (ST, cs)
@@ -21,10 +21,7 @@ import Thentos.Types
 
 
 thentosTestConfig :: IO ThentosConfig
-thentosTestConfig = do
-    cfg <- thentosTestConfigSources >>= configify
-    setRootPath cfg
-    return cfg
+thentosTestConfig = thentosTestConfigSources >>= getConfigWithSources
 
 thentosTestConfigSources :: IO [Source]
 thentosTestConfigSources = do
@@ -72,8 +69,9 @@ thentosTestConfigYaml = YamlString . cs . unlines $
     "captcha_expiration: 30m" :
     "" :
     "log:" :
-    "    path: ./log/thentos.log" :
-    "    level: DEBUG" :
+    "    path: /dev/null" :
+    "    level: EMERGENCY" :
+        -- (override this in individual test cases or use 'withLogger')
     "" :
     "signup_log: signups.log" :
     "" :

--- a/thentos-tests/src/Thentos/Test/Core.hs
+++ b/thentos-tests/src/Thentos/Test/Core.hs
@@ -202,11 +202,11 @@ createActionState' cfg = ActionState cfg <$> (drgNew >>= newMVar) <*> createDb c
 
 -- | Create a connection to a DB.  Whipes the DB.
 createDb :: ThentosConfig -> IO (Pool Connection)
-createDb cfg = callCommand (create_ <> " && " <> wipe_) >> createConnPoolAndInitDb cfg
+createDb cfg = callCommand (createCmd <> " && " <> wipeCmd) >> createConnPoolAndInitDb cfg
   where
-    dbname  = cs $ cfg >>. (Proxy :: Proxy '["database", "name"])
-    create_ = "createdb " <> dbname <> " 2>/dev/null || true"
-    wipe_   = "psql --quiet --file=" <> wipeFile <> " " <> dbname <> " >/dev/null 2>&1"
+    dbname    = cs $ cfg >>. (Proxy :: Proxy '["database", "name"])
+    createCmd = "createdb " <> dbname <> " 2>/dev/null || true"
+    wipeCmd   = "psql --quiet --file=" <> wipeFile <> " " <> dbname <> " >/dev/null 2>&1"
 
 loginAsGod :: ActionState -> IO (ThentosSessionToken, Header)
 loginAsGod actionState = do

--- a/thentos-tests/src/Thentos/Test/Core.hs
+++ b/thentos-tests/src/Thentos/Test/Core.hs
@@ -165,7 +165,7 @@ withNoisyLogger action = do
     return result
 
 withSignupLogger :: IO a -> IO a
-withSignupLogger action = inTempDirectory $ do
+withSignupLogger action = Test.Mockery.Directory.inTempDirectory $ do
     removeAllHandlers
     updateGlobalLogger signupLogger $ setLevel DEBUG
     let addh h = addHandler $ h { formatter = nullFormatter }

--- a/thentos-tests/src/Thentos/Test/Core.hs
+++ b/thentos-tests/src/Thentos/Test/Core.hs
@@ -16,6 +16,8 @@
 {-# LANGUAGE TypeSynonymInstances       #-}
 {-# LANGUAGE ViewPatterns               #-}
 
+{-# OPTIONS_GHC  #-}
+
 module Thentos.Test.Core
 where
 
@@ -36,11 +38,6 @@ import Data.Void (Void)
 import Database.PostgreSQL.Simple (Connection)
 import Network.HTTP.Types.Header (Header)
 import System.Directory (getCurrentDirectory, setCurrentDirectory)
-import System.IO (stderr)
-import System.Log.Formatter (simpleLogFormatter)
-import System.Log.Handler.Simple (formatter, streamHandler)
-import System.Log.Logger (Priority(DEBUG), removeAllHandlers, updateGlobalLogger,
-                          setLevel, addHandler)
 import System.Process (callCommand)
 
 import qualified Data.Aeson as Aeson
@@ -48,7 +45,6 @@ import qualified Data.Aeson.Types as Aeson
 import qualified Test.Mockery.Directory (inTempDirectory)
 import qualified Test.WebDriver as WD
 
-import System.Log.Missing (loggerName)
 import Thentos.Action.Core
 import Thentos.Action.Types
 import Thentos.Action hiding (addUser)

--- a/thentos-tests/src/Thentos/Test/Core.hs
+++ b/thentos-tests/src/Thentos/Test/Core.hs
@@ -252,9 +252,8 @@ createActionState dbname config = do
 -- done.
 createDb :: String -> IO (Pool Connection)
 createDb dbname = do
-    wipe <- wipeFile
     callCommand $ "createdb " <> dbname <> " 2>/dev/null || true"
-               <> " && psql --quiet --file=" <> wipe <> " " <> dbname <> " >/dev/null 2>&1"
+               <> " && psql --quiet --file=" <> wipeFile <> " " <> dbname <> " >/dev/null 2>&1"
     createConnPoolAndInitDb $ cs dbname
 
 loginAsGod :: ActionState -> IO (ThentosSessionToken, [Header])

--- a/thentos-tests/src/Thentos/Test/Core.hs
+++ b/thentos-tests/src/Thentos/Test/Core.hs
@@ -164,16 +164,6 @@ withNoisyLogger action = do
     removeAllHandlers
     return result
 
-withSignupLogger :: IO a -> IO a
-withSignupLogger action = Test.Mockery.Directory.inTempDirectory $ do
-    removeAllHandlers
-    updateGlobalLogger signupLogger $ setLevel DEBUG
-    let addh h = addHandler $ h { formatter = nullFormatter }
-    fileHandler "./signups.log" DEBUG >>= updateGlobalLogger signupLogger . addh
-    result <- action
-    removeAllHandlers
-    return result
-
 -- | Start and shutdown webdriver on localhost:4451, running the action in between.
 withWebDriver :: WD.WD r -> IO r
 withWebDriver = withWebDriverAt' "localhost" 4451

--- a/thentos-tests/src/Thentos/Test/Core.hs
+++ b/thentos-tests/src/Thentos/Test/Core.hs
@@ -223,14 +223,14 @@ withBackend' beConfig as action = do
             killThread
             (const action)
 
-withFrontendAndBackend :: String -> (ActionState -> IO r) -> IO r
-withFrontendAndBackend dbname = inTempDirectory . withFrontendAndBackend' dbname
+withFrontendAndBackend :: (ActionState -> IO r) -> IO r
+withFrontendAndBackend = inTempDirectory . withFrontendAndBackend'
 
 -- | Sets up DB, frontend and backend, creates god user, runs an action that
 -- takes a DB, and tears down everything, returning the result of the action.
-withFrontendAndBackend' :: String -> (ActionState -> IO r) -> IO r
-withFrontendAndBackend' dbname test = do
-    st@(ActionState cfg _ connPool) <- createActionState dbname thentosTestConfig
+withFrontendAndBackend' :: (ActionState -> IO r) -> IO r
+withFrontendAndBackend' test = do
+    st@(ActionState cfg _ connPool) <- createActionState
     withFrontend' (getFrontendConfig cfg) st
         $ withBackend' (getBackendConfig cfg) st
             $ withResource connPool (\conn -> liftIO (createGod conn) >> test st)

--- a/thentos-tests/src/Thentos/Test/Core.hs
+++ b/thentos-tests/src/Thentos/Test/Core.hs
@@ -143,25 +143,6 @@ outsideTempDirectory action = do
         setCurrentDirectory wd
         action wd'
 
--- | Wrap a spec in `withNoisyLogger`, and everything will go to stderr.
---
--- FIXME: show log contents for failing test cases automatically.  or provide a log handler that
--- logs into a 'Chan', and exposes the Chan to the tests.  that would make it fast and easy to use
--- log file contents to formulate tests.
-withNoisyLogger :: IO a -> IO a
-withNoisyLogger action = do
-    removeAllHandlers
-    updateGlobalLogger loggerName $ setLevel DEBUG
-
-    let fmt = simpleLogFormatter "$utcTime *$prio* [$pid][$tid] -- $msg"
-        addh h = addHandler $ h { formatter = fmt }
-
-    streamHandler stderr DEBUG >>= updateGlobalLogger loggerName . addh
-
-    result <- action
-    removeAllHandlers
-    return result
-
 -- | Start and shutdown webdriver on localhost:4451, running the action in between.
 withWebDriver :: WD.WD r -> IO r
 withWebDriver = withWebDriverAt' "localhost" 4451

--- a/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
+++ b/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
@@ -136,5 +136,5 @@ specWithBackends = describe "hasPrivilegedIp" $ do
                 resp ^. Wreq.responseBody `shouldBe` Aeson.encode y
 
     works ["127.0.0.1"] True
-    works  ["1.2.3.4"] False
+    works ["1.2.3.4"] False
     works [] False

--- a/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
+++ b/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
@@ -111,8 +111,7 @@ specWithActionState = before mkActionState $ do
 
 withPrivIpBackend :: [String] -> (HttpConfig -> IO r) -> IO r
 withPrivIpBackend allowIps testCase = do
-    srcs <- thentosTestConfigSources
-    cfg <- getConfigWithSources $ srcs ++ [YamlString . ("allow_ips: " <>) . cs . show $ allowIps]
+    cfg <- thentosTestConfig' [YamlString . ("allow_ips: " <>) . cs . show $ allowIps]
     as <- createActionState' cfg
 
     let Just becfg = Tagged <$> (as ^. aStConfig) >>. (Proxy :: Proxy '["backend"])

--- a/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
+++ b/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
@@ -8,7 +8,7 @@ module Thentos.Action.SimpleAuthSpec where
 import Control.Concurrent (forkIO, killThread)
 import Control.Exception (bracket)
 import Control.Lens ((^.))
-import Data.Configifier (Source(YamlString), Tagged(Tagged), (>>.), configify)
+import Data.Configifier (Source(YamlString), Tagged(Tagged), (>>.))
 import Data.Pool (withResource)
 import Data.Proxy (Proxy(Proxy))
 import Data.String.Conversions (cs, (<>))
@@ -112,7 +112,7 @@ specWithActionState = before mkActionState $ do
 withPrivIpBackend :: [String] -> (HttpConfig -> IO r) -> IO r
 withPrivIpBackend allowIps testCase = do
     srcs <- thentosTestConfigSources
-    cfg <- configify $ srcs ++ [YamlString . ("allow_ips: " <>) . cs . show $ allowIps]
+    cfg <- getConfigWithSources $ srcs ++ [YamlString . ("allow_ips: " <>) . cs . show $ allowIps]
     as <- createActionState' cfg
 
     let Just becfg = Tagged <$> (as ^. aStConfig) >>. (Proxy :: Proxy '["backend"])

--- a/thentos-tests/tests/Thentos/Action/UnsafeSpec.hs
+++ b/thentos-tests/tests/Thentos/Action/UnsafeSpec.hs
@@ -31,7 +31,7 @@ type Act = Action (ActionError Void) ()
 
 mkActionState :: IO ActionState
 mkActionState = do
-    actionState <- createActionState "test_thentos" thentosTestConfig
+    actionState <- createActionState
     withResource (actionState ^. aStDb) createGod
     return actionState
 

--- a/thentos-tests/tests/Thentos/ActionSpec.hs
+++ b/thentos-tests/tests/Thentos/ActionSpec.hs
@@ -75,7 +75,7 @@ spec_user = describe "user" $ do
                 runClearanceE dcBottom sta $ lookupConfirmedUser uid
             return ()
 
-        it "guarantee that user names are unique" $ \ sta -> do
+        it "guarantee that user names are unique" $ \sta -> do
             (_, _, user) <- runClearance dcBottom sta $ addTestUser 1
             let userFormData = UserFormData (user ^. userName)
                                             (UserPass "foo")
@@ -84,7 +84,7 @@ spec_user = describe "user" $ do
                 addUser userFormData
             e `shouldBe` UserNameAlreadyExists
 
-        it "guarantee that user email addresses are unique" $ \ sta -> do
+        it "guarantee that user email addresses are unique" $ \sta -> do
             (_, _, user) <- runClearance dcBottom sta $ addTestUser 1
             let userFormData = UserFormData (UserName "newOne")
                                             (UserPass "foo")
@@ -138,24 +138,24 @@ spec_user = describe "user" $ do
                 checkSignupLog sta CaptchaIncorrect
 
     describe "DeleteUser" $ do
-        it "user can delete herself, even if not admin" $ \ sta -> do
+        it "user can delete herself, even if not admin" $ \sta -> do
             (uid, _, _) <- runClearance dcBottom sta $ addTestUser 3
             result <- runPrivsE [UserA uid] sta $ deleteUser uid
             result `shouldSatisfy` isRight
 
-        it "nobody else but the deleted user and admin can do this" $ \ sta -> do
+        it "nobody else but the deleted user and admin can do this" $ \sta -> do
             (uid,  _, _) <- runClearance dcBottom sta $ addTestUser 3
             (uid', _, _) <- runClearance dcBottom sta $ addTestUser 4
             result <- runPrivsE [UserA uid] sta $ deleteUser uid'
             result `shouldSatisfy` isLeft
 
     describe "checkPassword" $ do
-        it "works" $ \ sta -> do
+        it "works" $ \sta -> do
             void . runA sta $ startThentosSessionByUserId godUid godPass
             void . runA sta $ startThentosSessionByUserName godName godPass
 
     describe "confirmUserEmailChange" $ do
-        it "changes user email after change request" $ \ sta -> do
+        it "changes user email after change request" $ \sta -> do
             let newEmail = forceUserEmail "changed@example.com"
                 checkEmail uid p = do
                     (_, user) <- runPrivs [RoleAdmin] sta $ lookupConfirmedUser uid
@@ -173,7 +173,7 @@ spec_user = describe "user" $ do
 spec_service :: SpecWith ActionState
 spec_service = describe "service" $ do
     describe "addService, lookupService, deleteService" $ do
-        it "works" $ \ sta -> do
+        it "works" $ \sta -> do
             let addsvc name desc = runClearanceE (UserA godUid %% UserA godUid) sta
                     $ addService (UserId 0) name desc
             Right (service1_id, _s1_key) <- addsvc "fake name" "fake description"
@@ -188,7 +188,7 @@ spec_service = describe "service" $ do
             return ()
 
     describe "autocreateServiceIfMissing" $ do
-        it "adds service if missing" $ \ sta -> do
+        it "adds service if missing" $ \sta -> do
             let owner = UserId 0
             sid <- runPrivs [RoleAdmin] sta $ freshServiceId
             allSids <- runPrivs [RoleAdmin] sta allServiceIds
@@ -197,7 +197,7 @@ spec_service = describe "service" $ do
             allSids' <- runPrivs [RoleAdmin] sta allServiceIds
             allSids' `shouldContain` [sid]
 
-        it "does nothing if service exists" $ \ sta -> do
+        it "does nothing if service exists" $ \sta -> do
             let owner = UserId 0
             (sid, _) <- runPrivs [RoleAdmin] sta
                             $ addService owner "fake name" "fake description"
@@ -210,28 +210,28 @@ spec_agentsAndRoles :: SpecWith ActionState
 spec_agentsAndRoles = describe "agentsAndRoles" $ do
     describe "agents and roles" $ do
         describe "assign" $ do
-            it "can be called by admins" $ \ sta -> do
+            it "can be called by admins" $ \sta -> do
                 (UserA -> targetAgent, _, _) <- runClearance dcBottom sta $ addTestUser 1
                 result <- runPrivsE [RoleAdmin] sta $ assignRole targetAgent RoleAdmin
                 result `shouldSatisfy` isRight
 
-            it "can NOT be called by any non-admin agents" $ \ sta -> do
+            it "can NOT be called by any non-admin agents" $ \sta -> do
                 let targetAgent = UserA $ UserId 1
                 result <- runPrivsE [targetAgent] sta $ assignRole targetAgent RoleAdmin
                 result `shouldSatisfy` isLeft
 
         describe "lookup" $ do
-            it "can be called by admins" $ \ sta -> do
+            it "can be called by admins" $ \sta -> do
                 let targetAgent = UserA $ UserId 1
                 result <- runPrivsE [RoleAdmin] sta $ agentRoles targetAgent
                 result `shouldSatisfy` isRight
 
-            it "can be called by user for her own roles" $ \ sta -> do
+            it "can be called by user for her own roles" $ \sta -> do
                 let targetAgent = UserA $ UserId 1
                 result <- runPrivsE [targetAgent] sta $ agentRoles targetAgent
                 result `shouldSatisfy` isRight
 
-            it "can NOT be called by other users" $ \ sta -> do
+            it "can NOT be called by other users" $ \sta -> do
                 let targetAgent = UserA $ UserId 1
                     askingAgent = UserA $ UserId 2
                 result <- runPrivsE [askingAgent] sta $ agentRoles targetAgent
@@ -241,13 +241,13 @@ spec_agentsAndRoles = describe "agentsAndRoles" $ do
 spec_session :: SpecWith ActionState
 spec_session = describe "session" $ do
     describe "StartSession" $ do
-        it "works" $ \ sta -> do
+        it "works" $ \sta -> do
             result <- runAE sta $ startThentosSessionByUserName godName godPass
             result `shouldSatisfy` isRight
             return ()
 
     describe "lookupThentosSession" $ do
-        it "works" $ \ sta -> do
+        it "works" $ \sta -> do
             ((ernieId, ernieF, _) : (bertId, _, _) : _)
                 <- runClearance dcTop sta initializeTestUsers
 

--- a/thentos-tests/tests/Thentos/ActionSpec.hs
+++ b/thentos-tests/tests/Thentos/ActionSpec.hs
@@ -22,7 +22,7 @@ import LIO.DCLabel (ToCNF, DCLabel, (%%), toCNF)
 import System.FilePath ((</>))
 import System.Process (readProcess)
 import Test.Hspec (Spec, SpecWith, describe, it, around, shouldBe, shouldContain,
-                   shouldNotContain, shouldSatisfy, hspec, around_)
+                   shouldNotContain, shouldSatisfy, hspec)
 
 import qualified Data.ByteString.Lazy.Char8 as BC
 import qualified Data.Csv as CSV

--- a/thentos-tests/tests/Thentos/ActionSpec.hs
+++ b/thentos-tests/tests/Thentos/ActionSpec.hs
@@ -43,7 +43,7 @@ tests = hspec spec
 spec :: Spec
 spec = do
     let b = do
-          as <- createActionState "test_thentos" thentosTestConfig
+          as <- createActionState
           withResource (as ^. aStDb) createGod
           return as
 

--- a/thentos-tests/tests/Thentos/Backend/Api/CaptchaSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/CaptchaSpec.hs
@@ -23,7 +23,6 @@ import Test.Hspec.Wai (with, request)
 
 import Thentos.Action.Types
 import Thentos.Backend.Api.Captcha (serveFrontendApi, serveBackendApi)
-import Thentos.Test.Config
 import Thentos.Test.Core
 import Thentos.Test.Transaction
 import Thentos.Types
@@ -33,7 +32,7 @@ import qualified Data.ByteString.Lazy as LBS
 
 backendApp :: IO Application
 backendApp = do
-    as@(ActionState cfg _ connPool) <- createActionState "test_thentos" thentosTestConfig
+    as@(ActionState cfg _ connPool) <- createActionState
     void $ tryTakeMVar connPoolVar -- discard old value, if any
     putMVar connPoolVar connPool
     let Just beConfig = Tagged <$> cfg >>. (Proxy :: Proxy '["backend"])
@@ -41,7 +40,7 @@ backendApp = do
 
 frontendApp :: IO Application
 frontendApp = do
-    as@(ActionState cfg _ connPool) <- createActionState "test_thentos" thentosTestConfig
+    as@(ActionState cfg _ connPool) <- createActionState
     void $ tryTakeMVar connPoolVar -- discard old value, if any
     putMVar connPoolVar connPool
     let Just feConfig = Tagged <$> cfg >>. (Proxy :: Proxy '["frontend"])

--- a/thentos-tests/tests/Thentos/Backend/Api/PureScriptSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/PureScriptSpec.hs
@@ -30,7 +30,6 @@ import Test.Hspec (Spec, Spec, hspec, describe, context, around, around_, it, sh
 import Test.Hspec.Wai (shouldRespondWith, with, get)
 import Test.Hspec.Wai.Internal (WaiSession, runWaiSession)
 
-import Thentos.Config (getConfigWithSources)
 import Thentos.Action.Types
 import Thentos.Test.Config
 import Thentos.Test.Core
@@ -67,8 +66,7 @@ runSession havePurescript session tmp = defaultApp havePurescript >>= runWaiSess
 
 defaultApp :: Bool -> IO Application
 defaultApp havePurescript = do
-    srcs <- thentosTestConfigSources
-    cfg <- getConfigWithSources $ srcs ++ [ YamlString "purescript: ." | havePurescript ]
+    cfg <- thentosTestConfig' [ YamlString "purescript: ." | havePurescript ]
     as <- createActionState' cfg
     return $! serve (Proxy :: Proxy Api) (api havePurescript as)
 

--- a/thentos-tests/tests/Thentos/Backend/Api/PureScriptSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/PureScriptSpec.hs
@@ -62,8 +62,9 @@ specPurescript = around_ withLogger $ do
 
 defaultApp :: Bool -> IO Application
 defaultApp havePurescript = do
-    cfg <- configify $ thentosTestConfigYaml : [ YamlString "purescript: ." | havePurescript ]
-    as <- createActionState "test_thentos" cfg
+    srcs <- thentosTestConfigSources
+    cfg <- configify $ srcs ++ [ YamlString "purescript: ." | havePurescript ]
+    as <- createActionState' cfg
     return $! serve (Proxy :: Proxy Api) (api havePurescript as)
 
 type Api = "js" :> PureScript.Api

--- a/thentos-tests/tests/Thentos/Backend/Api/PureScriptSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/PureScriptSpec.hs
@@ -17,7 +17,7 @@ where
 
 import Control.Lens ((^.))
 import Control.Monad.State (liftIO)
-import Data.Configifier (Source(YamlString), configify)
+import Data.Configifier (Source(YamlString))
 import Data.Proxy (Proxy(Proxy))
 import Data.String.Conversions (cs)
 import Data.String (fromString)
@@ -29,6 +29,7 @@ import System.FilePath ((</>))
 import Test.Hspec (Spec, Spec, hspec, describe, context, around_, it, shouldContain)
 import Test.Hspec.Wai (shouldRespondWith, with, get)
 
+import Thentos.Config (getConfigWithSources)
 import Thentos.Action.Types
 import Thentos.Test.Config
 import Thentos.Test.Core
@@ -63,7 +64,7 @@ specPurescript = around_ withLogger $ do
 defaultApp :: Bool -> IO Application
 defaultApp havePurescript = do
     srcs <- thentosTestConfigSources
-    cfg <- configify $ srcs ++ [ YamlString "purescript: ." | havePurescript ]
+    cfg <- getConfigWithSources $ srcs ++ [ YamlString "purescript: ." | havePurescript ]
     as <- createActionState' cfg
     return $! serve (Proxy :: Proxy Api) (api havePurescript as)
 

--- a/thentos-tests/tests/Thentos/Backend/Api/PureScriptSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/PureScriptSpec.hs
@@ -26,7 +26,7 @@ import Network.Wai.Test (simpleHeaders)
 import Servant.API ((:>))
 import Servant.Server (serve, Server)
 import System.FilePath ((</>))
-import Test.Hspec (Spec, Spec, hspec, describe, context, around_, it, shouldContain)
+import Test.Hspec (Spec, Spec, hspec, describe, context, around, around_, it, shouldContain)
 import Test.Hspec.Wai (shouldRespondWith, with, get)
 
 import Thentos.Config (getConfigWithSources)
@@ -44,18 +44,18 @@ spec :: Spec
 spec = describe "Thentos.Backend.Api.PureScript" specPurescript
 
 specPurescript :: Spec
-specPurescript = around_ withLogger $ do
+specPurescript = around outsideTempDirectory $ do
     let jsFile :: FilePath = "find-me.js"
         body   :: String   = "9VA4I5xpOAXRE"
 
     context "When purescript path not given in config" . with (defaultApp False) $ do
-        it "response has status 404" $ do
-            liftIO $ writeFile jsFile body
+        it "response has status 404" $ \tmp -> do
+            liftIO $ writeFile (tmp </> jsFile) body
             get (cs $ "/js" </> jsFile) `shouldRespondWith` 404
 
     context "When path given in config" . with (defaultApp True) $ do
-        it "response has right status, body, headers" $ do
-            liftIO $ writeFile jsFile body
+        it "response has right status, body, headers" $ \tmp -> do
+            liftIO $ writeFile (tmp </> jsFile) body
             get (cs $ "/js" </> jsFile) `shouldRespondWith` 200
             get (cs $ "/js" </> jsFile) `shouldRespondWith` fromString body
             resp <- get (cs $ "/js" </> jsFile)

--- a/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
@@ -12,31 +12,33 @@
 {-# LANGUAGE TupleSections                            #-}
 {-# LANGUAGE TypeSynonymInstances                     #-}
 
-{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
+{-# OPTIONS_GHC #-}
 
 module Thentos.Backend.Api.SimpleSpec (spec, tests)
 where
 
-import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, readMVar, tryTakeMVar)
+import Control.Lens ((^.))
 import Control.Monad.State (liftIO)
 import Control.Monad (void)
-import Data.Configifier (Tagged(Tagged), (>>.))
-import Data.IORef (IORef, newIORef, writeIORef, readIORef)
+import Database.PostgreSQL.Simple (Only(..))
+import Database.PostgreSQL.Simple.SqlQQ (sql)
+import Data.Configifier (Tagged(Tagged), (>>.), Source(YamlString))
 import Data.Monoid ((<>))
-import Data.Pool (Pool, withResource)
+import Data.Pool (withResource)
 import Data.Proxy (Proxy(Proxy))
 import Data.String.Conversions (SBS, LBS, ST, cs)
-import Database.PostgreSQL.Simple (Connection, Only(..))
-import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Network.HTTP.Types.Header (Header)
 import Network.HTTP.Types.Status (statusCode)
 import Network.Wai (Application)
 import Network.Wai.Test (simpleBody, simpleHeaders, simpleStatus, SResponse)
-import System.IO.Unsafe (unsafePerformIO)
+import System.FilePath ((</>))
 import System.Process (readProcess)
-import Test.Hspec (Spec, SpecWith, around_, describe, it, shouldBe, shouldContain, shouldNotBe,
-                   pendingWith, hspec)
-import Test.Hspec.Wai (shouldRespondWith, WaiSession, with, request, matchStatus)
+import Test.Hspec
+    ( Spec, SpecWith, ActionWith, hspec, around, describe, it
+    , shouldBe, shouldContain, shouldNotBe )
+import Test.Hspec.Wai.Internal (runWaiSession)
+import Test.Hspec.Wai
+    (shouldRespondWith, WaiSession, with, request, matchStatus, pendingWith)
 
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
@@ -52,69 +54,76 @@ import Thentos.Test.DefaultSpec
 import Thentos.Test.Transaction
 
 
--- | FIXME: This is stuff also provided in a similar way from "Thentos.Test.Core".  remove redundancy!
-defaultApp :: IO Application
-defaultApp = do
-    as@(ActionState cfg _ connPool) <- createActionState
-    withResource connPool createGod
-    writeIORef godHeaders . snd =<< loginAsGod as
-    void $ tryTakeMVar connPoolVar  -- discard old value, if any
-    putMVar connPoolVar connPool
-    let Just beConfig = Tagged <$> cfg >>. (Proxy :: Proxy '["backend"])
-    return $! serveApi beConfig as
+-- | FIXME: This should be provided in a more general way from "Thentos.Test.Core".
+data ItsState = ItsState
+    { itsApplication :: Application
+    , itsActionState :: ActionState
+    , itsGodHeader   :: Header
+    }
+
+runIt :: (ItsState -> WaiSession a) -> ItsState -> IO a
+runIt session its = runWaiSession (session its) (itsApplication its)
+
+withIt :: ActionWith ItsState -> IO ()
+withIt action = outsideTempDirectory $ (action =<<) . setupIt . Just
+
+setupIt :: Maybe FilePath -> IO ItsState
+setupIt mTmp = do
+    let cfgExtra = [ YamlString . cs . unlines $
+                        "log:" :
+                        "  level: DEBUG" :
+                        "  stdout: False" :
+                        ["  path: " ++ maybe "/dev/null" (</> "log") mTmp] ]
+    cfg <- thentosTestConfig' cfgExtra
+    as <- createActionState' cfg
+    let Just becfg = Tagged <$> cfg >>. (Proxy :: Proxy '["backend"])
+        app = serveApi becfg as
+    withResource (as ^. aStDb) createGod
+    godHeader <- snd <$> loginAsGod as
+    return $! ItsState app as godHeader
 
 tests :: IO ()
 tests = hspec spec
 
-godHeaders :: IORef [Header]
-godHeaders = unsafePerformIO $ newIORef []
-{-# NOINLINE godHeaders #-}
-
-connPoolVar :: MVar (Pool Connection)
-connPoolVar = unsafePerformIO $ newEmptyMVar
-{-# NOINLINE connPoolVar #-}
-
 spec :: Spec
-spec = describe "Thentos.Backend.Api.Simple" $ with defaultApp specRest
+spec = describe "Thentos.Backend.Api.Simple" $ do
+    with (itsApplication <$> setupIt Nothing) specHasRestDocs
+    around withIt specRest
 
-specRest :: SpecWith Application
+specRest :: SpecWith ItsState
 specRest = do
-    specHasRestDocs
-
     describe "headers" $ do
-        it "bad unknown headers matching /X-Thentos-*/ yields an error response." $ do
-            hdr <- liftIO ctHeader
-            let headers = ("X-Thentos-No-Such-Header", "3"):hdr
+        it "bad unknown headers matching /X-Thentos-*/ yields an error response." . runIt $ \its -> do
+            let headers = [("X-Thentos-No-Such-Header", "3"), jsonHeader, itsGodHeader its]
             request "GET" "/user/0/email" headers "" `shouldRespondWith` 400
-
 
     describe "user" $ do
         describe "Capture \"userid\" UserId :> \"name\" :> Get (JsonTop UserName)" $ do
             let resource = "/user/0/name"
-            it "yields a name" $ do
-                hdr <- liftIO ctHeader
+            it "yields a name" . runIt $ \its -> do
+                let hdr = [jsonHeader, itsGodHeader its]
                 request "GET" resource hdr "" `shouldRespondWith` "{\"data\":\"god\"}"
 
-            it "can be called by user herself" $
-                    \ _ -> pendingWith "test missing."
+            it "can be called by user herself" . runIt $ \_its -> do
+                pendingWith "test missing."
 
-            it "can be called by admin" $ do
-                hdr <- liftIO ctHeader
+            it "can be called by admin" . runIt $ \its -> do
+                let hdr = [jsonHeader, itsGodHeader its]
                 request "GET" resource hdr "" `shouldRespondWith` 200
 
-            it "can not be called by other (non-admin) users" $
-                    \ _ -> pendingWith "test missing."
+            it "can not be called by other (non-admin) users" . runIt $ \_its -> do
+                pendingWith "test missing."
 
         describe "Capture \"userid\" UserId :> \"email\" :> Get (JsonTop UserEmail)" $ do
             let resource = "/user/0/email"
-            it "yields an email address" $ do
-                hdr <- liftIO ctHeader
+            it "yields an email address" . runIt $ \its -> do
+                let hdr = [jsonHeader, itsGodHeader its]
                 request "GET" resource hdr "" `shouldRespondWith` 200
 
         describe "ReqBody UserFormData :> Post (JsonTop UserId)" $ do
-            it "writes a new user to the database" $ do
-                hdr <- liftIO ctHeader
-                response1 <- postDefaultUser
+            it "writes a new user to the database" . runIt $ \its -> do
+                let hdr = [jsonHeader, itsGodHeader its]
+                response1 <- postDefaultUser its
                 return response1 `shouldRespondWith` 201
 
                 let Right (uid :: Int) = decodeJsonTop $ simpleBody response1
@@ -123,13 +132,13 @@ specRest = do
                 let Right top2 = decodeJsonTop $ simpleBody response2
                 liftIO $ top2 `shouldBe` udName defaultUserData
 
-            it "can only be called by admins" $
-                    \ _ -> pendingWith "test missing."
+            it "can only be called by admins" . runIt $ \_its -> do
+                pendingWith "test missing."
 
         describe "Capture \"userid\" UserId :> Delete" $ do
-            it "removes an existing user from the database" $ do
-                hdr <- liftIO ctHeader
-                response1 <- postDefaultUser
+            it "removes an existing user from the database" . runIt $ \its -> do
+                let hdr = [jsonHeader, itsGodHeader its]
+                response1 <- postDefaultUser its
                 let Right (uid :: Int) = decodeJsonTop $ simpleBody response1
                 request "GET" ("/user/" <> (cs . show $ uid) <> "/name") hdr ""
                     `shouldRespondWith` 200
@@ -137,215 +146,212 @@ specRest = do
                 request "GET" ("/user/" <> cs (show uid) <> "/name") hdr ""
                     `shouldRespondWith` 404
 
-            it "can only be called by admins and the user herself" $
-                    \ _ -> pendingWith "test missing."
+            it "can only be called by admins and the user herself" . runIt $ \_its -> do
+                pendingWith "test missing."
 
-            it "if user does not exist, responds with a 404" $ do
-                hdr <- liftIO ctHeader
+            it "if user does not exist, responds with a 404" . runIt $ \its -> do
+                let hdr = [jsonHeader, itsGodHeader its]
                 request "DELETE" "/user/1797" hdr "" `shouldRespondWith` 404
 
         describe "captcha POST" $ do
-            it "returns a PNG image with Thentos-Captcha-Id header" $ do
+            it "returns a PNG image with Thentos-Captcha-Id header" . runIt $ \_its -> do
                 rsp <- request "POST" "/user/captcha" [] ""
                 liftIO $ statusCode (simpleStatus rsp) `shouldBe` 201
                 -- Check for magic bytes at start of PNG
                 liftIO $ LBS.take 4 (simpleBody rsp) `shouldBe` "\137PNG"
                 liftIO $ map fst (simpleHeaders rsp) `shouldContain` ["Thentos-Captcha-Id"]
 
-            it "returns different data on repeated calls" $ do
+            it "returns different data on repeated calls" . runIt $ \_its -> do
                 rsp1 <- request "POST" "/user/captcha" [] ""
                 rsp2 <- request "POST" "/user/captcha" [] ""
                 liftIO $ simpleBody rsp1 `shouldNotBe` simpleBody rsp2
 
-        let getCaptchaAndSolution :: WaiSession (SBS, ST)
-            getCaptchaAndSolution = do
+        let getCaptchaAndSolution :: ItsState -> WaiSession (SBS, ST)
+            getCaptchaAndSolution its = do
                 crsp <- request "POST" "/user/captcha" [] ""
                 let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
-                connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
-                [Only solution] <- liftIO $ doQuery connPool
+                [Only solution] <- liftIO $ doQuery (itsActionState its ^. aStDb)
                     [sql| SELECT solution FROM captchas WHERE id = ? |] (Only cid)
                 return (cid, solution)
 
         describe "register POST" $ do
-            it "responds with 204 No Content and sends mail with confirmation token" $ do
-                (cid, solution) <- getCaptchaAndSolution
+            let grepLogFile :: ItsState -> String -> WaiSession String
+                grepLogFile its line = liftIO $ do
+                    let logFile :: FilePath
+                        logFile = cs $ (itsActionState its ^. aStConfig)
+                            >>. (Proxy :: Proxy '["log", "path"])
+                    readProcess "grep" [line, logFile] ""
+
+            it "responds with 204 No Content and sends mail with confirmation token" . runIt $ \its -> do
+                (cid, solution) <- getCaptchaAndSolution its
                 -- Register user
                 let csol    = CaptchaSolution (CaptchaId $ cs cid) solution
                     reqBody = Aeson.encode $ UserCreationRequest defaultUserData csol
-                request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 204
+                request "POST" "/user/register" [jsonHeader] reqBody `shouldRespondWith` 204
                 -- Find token in sent email and make sure it's correct
                 let actPrefix = "/activate/"
-                actLine <- liftIO $ readProcess "grep" [actPrefix, "everything.log"] ""
+                actLine <- grepLogFile its actPrefix
                 let sentToken = ST.take 24 . snd $ ST.breakOnEnd (cs actPrefix) (cs actLine)
-                connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
-                [Only (actualTok :: ConfirmationToken)] <- liftIO $ doQuery connPool
+                [Only (actualTok :: ConfirmationToken)] <- liftIO $ doQuery (itsActionState its ^. aStDb)
                     [sql| SELECT token FROM user_confirmation_tokens |] ()
                 liftIO $ sentToken `shouldBe` fromConfirmationToken actualTok
 
-            it "responds with 204 No Content and sends warn mail if email is duplicate" $ do
-                (cid, solution) <- getCaptchaAndSolution
+            it "responds with 204 No Content and sends warn mail if email is duplicate" . runIt $ \its -> do
+                (cid, solution) <- getCaptchaAndSolution its
                 -- Create user
-                void postDefaultUser
+                void $ postDefaultUser its
                 -- Try to register another user with the same email
                 let csol    = CaptchaSolution (CaptchaId $ cs cid) solution
                     user    = UserFormData "Another" "pwd" (udEmail defaultUserData)
                     reqBody = Aeson.encode $ UserCreationRequest user csol
-                request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 204
+                request "POST" "/user/register" [jsonHeader] reqBody `shouldRespondWith` 204
                 -- Check that no confirmation token was generated
-                connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
-                liftIO $ rowCountShouldBe connPool "user_confirmation_tokens" 0
+                liftIO $ rowCountShouldBe (itsActionState its ^. aStDb) "user_confirmation_tokens" 0
                 -- Check that "Attempted Signup" mail was sent
-                actLine <- liftIO $
-                    readProcess "grep" ["Thentos: Attempted Signup", "everything.log"] ""
+                actLine <- grepLogFile its "Thentos: Attempted Signup"
                 liftIO $ actLine `shouldNotBe` ""
 
-            it "refuses to accept the correct solution to the same captcha twice" $ do
-                (cid, solution) <- getCaptchaAndSolution
+            it "refuses to accept the correct solution to the same captcha twice" . runIt $ \its -> do
+                (cid, solution) <- getCaptchaAndSolution its
                 -- Register user
                 let csol    = CaptchaSolution (CaptchaId $ cs cid) solution
                     reqBody = Aeson.encode $ UserCreationRequest defaultUserData csol
-                request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 204
+                request "POST" "/user/register" [jsonHeader] reqBody `shouldRespondWith` 204
                 -- Try to register another user
                 let user2    = UserFormData "name2" "pwd" $ forceUserEmail "another@example.org"
                     reqBody2 = Aeson.encode $ UserCreationRequest user2 csol
-                request "POST" "/user/register" jsonHeader reqBody2 `shouldRespondWith` 400
+                request "POST" "/user/register" [jsonHeader] reqBody2 `shouldRespondWith` 400
 
-            it "allows resubmitting the same captcha solution if the user name was not unique" $ do
-                (cid, solution) <- getCaptchaAndSolution
+            it "allows resubmitting the same captcha solution if the user name was not unique" . runIt $ \its -> do
+                (cid, solution) <- getCaptchaAndSolution its
                 -- Create user
-                void postDefaultUser
+                void $ postDefaultUser its
                 -- Try to register another user with the same name
                 let csol    = CaptchaSolution (CaptchaId $ cs cid) solution
                     user    = UserFormData (udName defaultUserData) "pwd" $
                                            forceUserEmail "another@example.org"
                     reqBody = Aeson.encode $ UserCreationRequest user csol
-                request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 403
+                request "POST" "/user/register" [jsonHeader] reqBody `shouldRespondWith` 403
                 -- Try again using a new user name
                 let user2    = user { udName = "newname" }
                     reqBody2 = Aeson.encode $ UserCreationRequest user2 csol
-                request "POST" "/user/register" jsonHeader reqBody2 `shouldRespondWith` 204
+                request "POST" "/user/register" [jsonHeader] reqBody2 `shouldRespondWith` 204
 
-            it "fails if called without correct captcha ID" $ do
+            it "fails if called without correct captcha ID" . runIt $ \_its -> do
                 let csol    = CaptchaSolution "no-such-id" "dummy"
                     reqBody = Aeson.encode $ UserCreationRequest defaultUserData csol
-                request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 400
+                request "POST" "/user/register" [jsonHeader] reqBody `shouldRespondWith` 400
 
-            it "fails if called without correct captcha solution" $ do
+            it "fails if called without correct captcha solution" . runIt $ \_its -> do
                 crsp <- request "POST" "/user/captcha" [] ""
                 let Just cid = lookup "Thentos-Captcha-Id" $ simpleHeaders crsp
                 let csol    = CaptchaSolution (CaptchaId $ cs cid) "probably wrong"
                     reqBody = Aeson.encode $ UserCreationRequest defaultUserData csol
-                request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 400
+                request "POST" "/user/register" [jsonHeader] reqBody `shouldRespondWith` 400
 
         -- Note: this code assumes that there is just one unconfirmed user in the DB.
-        let registerUserAndGetConfirmationToken :: (SBS, ST) -> WaiSession ConfirmationToken
-            registerUserAndGetConfirmationToken (cid, solution) = do
+        let registerUserAndGetConfirmationToken :: ItsState -> (SBS, ST) -> WaiSession ConfirmationToken
+            registerUserAndGetConfirmationToken its (cid, solution) = do
                 -- Register user and get confirmation token
                 let csol     = CaptchaSolution (CaptchaId $ cs cid) solution
                     rreqBody = Aeson.encode $ UserCreationRequest defaultUserData csol
-                void $ request "POST" "/user/register" jsonHeader rreqBody
-                connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
+                void $ request "POST" "/user/register" [jsonHeader] rreqBody
                 -- There should be just one token in the DB
-                [Only (confTok :: ConfirmationToken)] <- liftIO $ doQuery connPool
+                [Only (confTok :: ConfirmationToken)] <- liftIO $ doQuery (itsActionState its ^. aStDb)
                     [sql| SELECT token FROM user_confirmation_tokens |] ()
                 return confTok
 
         describe "activate POST" $ do
-            it "activates a new user" $ do
-                (cid, solution) <- getCaptchaAndSolution
-                confTok <- registerUserAndGetConfirmationToken (cid, solution)
+            it "activates a new user" . runIt $ \its -> do
+                (cid, solution) <- getCaptchaAndSolution its
+                confTok <- registerUserAndGetConfirmationToken its (cid, solution)
                 -- Activate user
                 let areqBody = Aeson.encode $ JsonTop confTok
-                arsp <- request "POST" "/user/activate" jsonHeader areqBody
+                arsp <- request "POST" "/user/activate" [jsonHeader] areqBody
                 liftIO $ statusCode (simpleStatus arsp) `shouldBe` 201
                 let Right (sessTok :: ThentosSessionToken) = decodeJsonTop $ simpleBody arsp
                 liftIO $ fromThentosSessionToken sessTok `shouldNotBe` ""
 
-            it "fails if called again" $ do
-                (cid, solution) <- getCaptchaAndSolution
-                confTok <- registerUserAndGetConfirmationToken (cid, solution)
+            it "fails if called again" . runIt $ \its -> do
+                (cid, solution) <- getCaptchaAndSolution its
+                confTok <- registerUserAndGetConfirmationToken its (cid, solution)
                 -- Activate user
                 let areqBody = Aeson.encode $ JsonTop confTok
-                arsp <- request "POST" "/user/activate" jsonHeader areqBody
+                arsp <- request "POST" "/user/activate" [jsonHeader] areqBody
                 liftIO $ statusCode (simpleStatus arsp) `shouldBe` 201
                 -- Try to activate again
-                request "POST" "/user/activate" jsonHeader areqBody `shouldRespondWith` 400
+                request "POST" "/user/activate" [jsonHeader] areqBody `shouldRespondWith` 400
 
-            it "fails if called without valid ConfirmationToken" $ do
+            it "fails if called without valid ConfirmationToken" . runIt $ \_its -> do
                 let reqBody = Aeson.encode . JsonTop $ ConfirmationToken "no-such-token"
-                request "POST" "/user/activate" jsonHeader reqBody `shouldRespondWith` 400
+                request "POST" "/user/activate" [jsonHeader] reqBody `shouldRespondWith` 400
 
         describe "login POST" $ do
-            it "logs an activated user in" $ do
-                (cid, solution) <- getCaptchaAndSolution
-                confTok <- registerUserAndGetConfirmationToken (cid, solution)
+            it "logs an activated user in" . runIt $ \its -> do
+                (cid, solution) <- getCaptchaAndSolution its
+                confTok <- registerUserAndGetConfirmationToken its (cid, solution)
                 -- Activate user
                 let areqBody = Aeson.encode $ JsonTop confTok
-                arsp <- request "POST" "/user/activate" jsonHeader areqBody
+                arsp <- request "POST" "/user/activate" [jsonHeader] areqBody
                 liftIO $ statusCode (simpleStatus arsp) `shouldBe` 201
                 -- Log them in
                 let loginData = LoginFormData (udName defaultUserData) (udPassword defaultUserData)
-                lrsp <- request "POST" "/user/login" jsonHeader $ Aeson.encode loginData
+                lrsp <- request "POST" "/user/login" [jsonHeader] $ Aeson.encode loginData
                 liftIO $ statusCode (simpleStatus lrsp) `shouldBe` 201
                 let Right (sessTok :: ThentosSessionToken) = decodeJsonTop $ simpleBody lrsp
                 liftIO $ fromThentosSessionToken sessTok `shouldNotBe` ""
 
-            it "fails in the same way if user doesn't exist or password is wrong" $ do
-                void postDefaultUser
+            it "fails in the same way if user doesn't exist or password is wrong" . runIt $ \its -> do
+                void $ postDefaultUser its
                 let loginData1 = LoginFormData "wrong name" (udPassword defaultUserData)
-                rsp1 <- request "POST" "/user/login" jsonHeader $ Aeson.encode loginData1
+                rsp1 <- request "POST" "/user/login" [jsonHeader] $ Aeson.encode loginData1
                 liftIO $ statusCode (simpleStatus rsp1) `shouldBe` 401
                 let loginData2 = LoginFormData (udName defaultUserData) "wrong pass"
-                rsp2 <- request "POST" "/user/login" jsonHeader $ Aeson.encode loginData2
+                rsp2 <- request "POST" "/user/login" [jsonHeader] $ Aeson.encode loginData2
                 liftIO $ statusCode (simpleStatus rsp2) `shouldBe` 401
                 liftIO $ simpleBody rsp1 `shouldBe` simpleBody rsp2
 
-            it "fails if user isn't yet activated" $ do
-                (cid, solution) <- getCaptchaAndSolution
+            it "fails if user isn't yet activated" . runIt $ \its -> do
+                (cid, solution) <- getCaptchaAndSolution its
                 -- Register user
                 let csol    = CaptchaSolution (CaptchaId $ cs cid) solution
                     rreqBody = Aeson.encode $ UserCreationRequest defaultUserData csol
-                void $ request "POST" "/user/register" jsonHeader rreqBody
+                void $ request "POST" "/user/register" [jsonHeader] rreqBody
                 -- Try to log them in
                 let loginData = LoginFormData (udName defaultUserData) (udPassword defaultUserData)
-                lrsp <- request "POST" "/user/login" jsonHeader $ Aeson.encode loginData
+                lrsp <- request "POST" "/user/login" [jsonHeader] $ Aeson.encode loginData
                 liftIO $ statusCode (simpleStatus lrsp) `shouldBe` 401
 
 
     describe "thentos_session" $ do
         describe "ReqBody '[JSON] ThentosSessionToken :> Get Bool" $ do
-            it "returns true if session is active" $ do
-                hdr <- liftIO ctHeader
-                response1 <- postDefaultUser
+            it "returns true if session is active" . runIt $ \its -> do
+                let hdr = [jsonHeader, itsGodHeader its]
+                response1 <- postDefaultUser its
                 let Right uid = decodeJsonTop $ simpleBody response1
                 response2 <- request "POST" "/thentos_session" hdr $
                     Aeson.encode $ ByUser (UserId uid, udPassword defaultUserData)
                 request "GET" "/thentos_session/" hdr (simpleBody response2)
                     `shouldRespondWith` "true" { matchStatus = 200 }
 
-            it "returns false if session is does not exist" $ do
-                void postDefaultUser
-                hdr <- liftIO ctHeader
+            it "returns false if session is does not exist" . runIt $ \its -> do
+                void $ postDefaultUser its
+                let hdr = [jsonHeader, itsGodHeader its]
                 request "GET" "/thentos_session/" hdr (Aeson.encode ("x" :: ThentosSessionToken))
                     `shouldRespondWith` "false" { matchStatus = 200 }
 
 
--- | Parse and unwrap an element wrapped in JsonTop. Returns the element, if parsing is successful,
+-- | Parse and unwrap an element wrapped in JsonTop.
 decodeJsonTop :: Aeson.FromJSON a => LBS -> Either String a
 decodeJsonTop bs = fromJsonTop <$> Aeson.eitherDecode bs
 
-postDefaultUser :: WaiSession SResponse
-postDefaultUser = do
-    hdr <- liftIO ctHeader
-    request "POST" "/user" hdr (Aeson.encode defaultUserData)
+postDefaultUser :: ItsState -> WaiSession SResponse
+postDefaultUser its = do
+    request "POST" "/user" [jsonHeader, itsGodHeader its] (Aeson.encode defaultUserData)
 
 -- | Set content type to JSON.
-jsonHeader :: [Header]
-jsonHeader = [("Content-Type", "application/json")]
-
--- | God Headers plus content-type = json
-ctHeader :: IO [Header]
-ctHeader = (("Content-Type", "application/json") :) <$> readIORef godHeaders
+jsonHeader :: Header
+jsonHeader = ("Content-Type", "application/json")
 
 defaultUserData :: UserFormData
 defaultUserData = UserFormData "name" "pwd" $ forceUserEmail "somebody@example.org"

--- a/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
@@ -55,7 +55,7 @@ import Thentos.Test.Transaction
 -- | FIXME: This is stuff also provided in a similar way from "Thentos.Test.Core".  remove redundancy!
 defaultApp :: IO Application
 defaultApp = do
-    as@(ActionState cfg _ connPool) <- createActionState "test_thentos" thentosTestConfig
+    as@(ActionState cfg _ connPool) <- createActionState
     withResource connPool createGod
     writeIORef godHeaders . snd =<< loginAsGod as
     void $ tryTakeMVar connPoolVar  -- discard old value, if any

--- a/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
@@ -167,38 +167,37 @@ specRest = do
                 return (cid, solution)
 
         describe "register POST" $ do
-            around_ withLogger $ do
-                it "responds with 204 No Content and sends mail with confirmation token" $ do
-                    (cid, solution) <- getCaptchaAndSolution
-                    -- Register user
-                    let csol    = CaptchaSolution (CaptchaId $ cs cid) solution
-                        reqBody = Aeson.encode $ UserCreationRequest defaultUserData csol
-                    request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 204
-                    -- Find token in sent email and make sure it's correct
-                    let actPrefix = "/activate/"
-                    actLine <- liftIO $ readProcess "grep" [actPrefix, "everything.log"] ""
-                    let sentToken = ST.take 24 . snd $ ST.breakOnEnd (cs actPrefix) (cs actLine)
-                    connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
-                    [Only (actualTok :: ConfirmationToken)] <- liftIO $ doQuery connPool
-                        [sql| SELECT token FROM user_confirmation_tokens |] ()
-                    liftIO $ sentToken `shouldBe` fromConfirmationToken actualTok
+            it "responds with 204 No Content and sends mail with confirmation token" $ do
+                (cid, solution) <- getCaptchaAndSolution
+                -- Register user
+                let csol    = CaptchaSolution (CaptchaId $ cs cid) solution
+                    reqBody = Aeson.encode $ UserCreationRequest defaultUserData csol
+                request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 204
+                -- Find token in sent email and make sure it's correct
+                let actPrefix = "/activate/"
+                actLine <- liftIO $ readProcess "grep" [actPrefix, "everything.log"] ""
+                let sentToken = ST.take 24 . snd $ ST.breakOnEnd (cs actPrefix) (cs actLine)
+                connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
+                [Only (actualTok :: ConfirmationToken)] <- liftIO $ doQuery connPool
+                    [sql| SELECT token FROM user_confirmation_tokens |] ()
+                liftIO $ sentToken `shouldBe` fromConfirmationToken actualTok
 
-                it "responds with 204 No Content and sends warn mail if email is duplicate" $ do
-                    (cid, solution) <- getCaptchaAndSolution
-                    -- Create user
-                    void postDefaultUser
-                    -- Try to register another user with the same email
-                    let csol    = CaptchaSolution (CaptchaId $ cs cid) solution
-                        user    = UserFormData "Another" "pwd" (udEmail defaultUserData)
-                        reqBody = Aeson.encode $ UserCreationRequest user csol
-                    request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 204
-                    -- Check that no confirmation token was generated
-                    connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
-                    liftIO $ rowCountShouldBe connPool "user_confirmation_tokens" 0
-                    -- Check that "Attempted Signup" mail was sent
-                    actLine <- liftIO $
-                        readProcess "grep" ["Thentos: Attempted Signup", "everything.log"] ""
-                    liftIO $ actLine `shouldNotBe` ""
+            it "responds with 204 No Content and sends warn mail if email is duplicate" $ do
+                (cid, solution) <- getCaptchaAndSolution
+                -- Create user
+                void postDefaultUser
+                -- Try to register another user with the same email
+                let csol    = CaptchaSolution (CaptchaId $ cs cid) solution
+                    user    = UserFormData "Another" "pwd" (udEmail defaultUserData)
+                    reqBody = Aeson.encode $ UserCreationRequest user csol
+                request "POST" "/user/register" jsonHeader reqBody `shouldRespondWith` 204
+                -- Check that no confirmation token was generated
+                connPool :: Pool Connection <- liftIO $ readMVar connPoolVar
+                liftIO $ rowCountShouldBe connPool "user_confirmation_tokens" 0
+                -- Check that "Attempted Signup" mail was sent
+                actLine <- liftIO $
+                    readProcess "grep" ["Thentos: Attempted Signup", "everything.log"] ""
+                liftIO $ actLine `shouldNotBe` ""
 
             it "refuses to accept the correct solution to the same captcha twice" $ do
                 (cid, solution) <- getCaptchaAndSolution

--- a/thentos-tests/tests/Thentos/Frontend/Handlers/CombinatorsSpec.hs
+++ b/thentos-tests/tests/Thentos/Frontend/Handlers/CombinatorsSpec.hs
@@ -24,7 +24,6 @@ import Thentos.Frontend.State
 import Thentos.Frontend.Types
 
 import Thentos.Test.Arbitrary ()
-import Thentos.Test.Config
 import Thentos.Test.Core
 
 
@@ -42,9 +41,7 @@ apiRedirect :: ServerT ApiRedirect FAction
 apiRedirect = redirect' "/there"
 
 appRedirect :: IO Application
-appRedirect =
-    createActionState "thentos_test" thentosTestConfig >>=
-    serveFAction (Proxy :: Proxy ApiRedirect) apiRedirect
+appRedirect = createActionState >>= serveFAction (Proxy :: Proxy ApiRedirect) apiRedirect
 
 specRedirect :: Spec
 specRedirect = do

--- a/thentos-tests/tests/Thentos/Frontend/StateSpec.hs
+++ b/thentos-tests/tests/Thentos/Frontend/StateSpec.hs
@@ -33,7 +33,6 @@ import Thentos.Frontend.State
 import Thentos.Frontend.Types
 import Thentos.Types
 
-import Thentos.Test.Config
 import Thentos.Test.Core
 
 
@@ -87,7 +86,7 @@ spec_frontendState = do
             -- (https://github.com/haskell-servant/servant/issues/257), or in a small middleware.
             liftIO $ cs (simpleBody resp) `shouldContain` ("<!DOCTYPE HTML>" :: String)
 
-    describe "the FAction monad, via warp" . around (withFrontendAndBackend "thentos_test_db") $ do
+    describe "the FAction monad, via warp" . around withFrontendAndBackend $ do
         let mkurl :: ActionState -> ST -> String
             mkurl as = cs . (exposeUrl (getFrontendConfig (as ^. aStConfig)) <//>)
 
@@ -157,5 +156,4 @@ testApi = post_ :<|> read_
     read_ = gets ((cs . show <$>) . (^. fsdMessages))
 
 testApp :: IO Application
-testApp = createActionState "thentos_test" thentosTestConfig
-      >>= serveFAction (Proxy :: Proxy TestApi) testApi
+testApp = createActionState >>= serveFAction (Proxy :: Proxy TestApi) testApi

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -35,7 +35,7 @@ tests = hspec spec
 
 spec :: Spec
 spec = describe "selenium grid"
-         . around (withLogger . withFrontendAndBackend "test_thentos") $ do
+         . around (withLogger . withFrontendAndBackend) $ do
     spec_createUser
     spec_resetPassword
     spec_logIntoThentos

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -34,8 +34,7 @@ tests :: IO ()
 tests = hspec spec
 
 spec :: Spec
-spec = describe "selenium grid"
-         . around (withLogger . withFrontendAndBackend) $ do
+spec = describe "selenium grid" . around withFrontendAndBackend $ do
     spec_createUser
     spec_resetPassword
     spec_logIntoThentos

--- a/thentos-tests/tests/Thentos/Sybil/CaptchaSpec.hs
+++ b/thentos-tests/tests/Thentos/Sybil/CaptchaSpec.hs
@@ -25,7 +25,6 @@ import qualified Data.ByteString as SBS
 import Thentos.Action.Core
 import Thentos.Action.Types
 import Thentos.Sybil
-import Thentos.Test.Config (thentosTestConfig)
 import Thentos.Test.Core (createActionState)
 import Thentos.Types
 
@@ -72,7 +71,7 @@ spec = describe "Thentos.Sybil.Captcha" $ do
 
 generateAudioCaptcha' :: String -> Random20 -> IO (SBS, ST)
 generateAudioCaptcha' voice rnd = fst <$> do
-    as <- createActionState "test_thentos" thentosTestConfig
+    as <- createActionState
     runAction () as $ (generateAudioCaptcha voice rnd :: Action Void () (SBS, ST))
 
 mkRandom20' :: IO Random20

--- a/thentos-tests/tests/Thentos/TransactionSpec.hs
+++ b/thentos-tests/tests/Thentos/TransactionSpec.hs
@@ -25,7 +25,7 @@ import Thentos.Test.Config
 import Thentos.Test.Transaction
 
 spec :: Spec
-spec = describe "Thentos.Transaction" . before (createDb "test_thentos")
+spec = describe "Thentos.Transaction" . before (thentosTestConfig >>= createDb)
   $ do
     addUserPrimSpec
     addUserSpec

--- a/thentos-tests/tests/Thentos/TypesSpec.hs
+++ b/thentos-tests/tests/Thentos/TypesSpec.hs
@@ -20,6 +20,7 @@ import Test.QuickCheck (property)
 import Thentos.Types
 
 import Thentos.Test.Arbitrary ()
+import Thentos.Test.Config
 import Thentos.Test.Core
 import Thentos.Test.Transaction
 
@@ -29,7 +30,7 @@ testSizeFactor = 1
 spec :: Spec
 spec = do
     typesSpec
-    before (createDb "test_thentos") dbSpec
+    before (thentosTestConfig >>= createDb) dbSpec
 
 typesSpec :: Spec
 typesSpec = modifyMaxSize (* testSizeFactor) $ do

--- a/thentos-tests/thentos-tests.cabal
+++ b/thentos-tests/thentos-tests.cabal
@@ -50,6 +50,7 @@ library
     , case-insensitive >=1.2.0.4 && <1.3
     , configifier >=0.0.8 && <0.1
     , containers >=0.5.6.2 && <0.6
+    , directory >=1.2.2.0 && <1.3
     , cryptonite >=0.6 && <0.8
     , filepath >=1.4.0.0 && <1.5
     , hslogger >=1.2.9 && <1.3


### PR DESCRIPTION
The original purpose of this branch is to get rid of absolute path names in compiled executables, which I suspect are served by cabal's `getDataFileName` in the generated module `Path_package_name`.

The config type now allows for a field `root_path` that is `.` by default.  Since this is configifier, you can also use the cli or set `ROOT_PATH` in the shell environment if `.` is not adequate.

I also cleaned up the test suite to work with the new content type and create databases and action states in a more coherent way.