### PR TITLE
Fix audio captchas and generally discard whitespace in captchas

### DIFF
--- a/thentos-core/src/Thentos/Action.hs
+++ b/thentos-core/src/Thentos/Action.hs
@@ -703,6 +703,7 @@ makeCaptcha = do
     random <- freshRandom20
     (imgdata, solution) <- U.unsafeLiftIO $ Sybil.generateCaptcha random
     queryA $ T.storeCaptcha cid solution
+    loggerA DEBUG $ show cid
     pure (cid, imgdata)
 
 -- | Argument must be an espeak voice installed on the server system.  Try "en", "de", "fi", "ru" or
@@ -713,6 +714,7 @@ makeAudioCaptcha eSpeakVoice = do
     random <- freshRandom20
     (wav, solution) <- Sybil.generateAudioCaptcha eSpeakVoice random
     queryA $ T.storeCaptcha cid solution
+    loggerA DEBUG $ show cid
     pure (cid, wav)
 
 -- | Submit a solution to a captcha, returning whether or not the solution is correct.
@@ -722,6 +724,7 @@ makeAudioCaptcha eSpeakVoice = do
 solveCaptcha :: CaptchaId -> ST -> Action e s Bool
 solveCaptcha cid solution = do
     solutionCorrect <- queryA $ T.solveCaptcha cid solution
+    loggerA DEBUG $ show (cid, solution, solutionCorrect)
     unless solutionCorrect $ deleteCaptcha cid
     return solutionCorrect
 

--- a/thentos-tests/tests/Thentos/ActionSpec.hs
+++ b/thentos-tests/tests/Thentos/ActionSpec.hs
@@ -224,7 +224,7 @@ spec_captcha = describe "captcha" $ do
             count `shouldBe` (0 :: Int)
   where
     cid      = "RandomId"
-    solution = "some text"
+    solution = "some-text"
 
 -- specialize to error type 'Void' and state '()'
 runA :: ActionState -> Action Void () a -> IO a


### PR DESCRIPTION
Audio captchas where stored in the form "1 2 3 4 5 6", so when users typed "123456", the solution was rejected. Now whitespace is generally ignored and discarded, for both visual and audio captchas. This also means that users can submit visual captcha solutions in the form "abc def" or "abcdef", and both will be accepted.