### PR TITLE
Support import of bcrypt data.

### DIFF
--- a/thentos-adhocracy/src/Thentos/Adhocracy3/Action/Types.hs
+++ b/thentos-adhocracy/src/Thentos/Adhocracy3/Action/Types.hs
@@ -312,7 +312,7 @@ instance FromJSON LoginRequest where
     parseJSON = withObject "login request" $ \v -> do
         name <- UserName  <$$> v .:? "name"
         email <- v .:? "email"
-        pass <- UserPass  <$>  v .: "password"
+        pass <- UserPass <$>  v .: "password"
         case (name, email) of
           (Just x,  Nothing) -> return $ LoginByName x pass
           (Nothing, Just x)  -> return $ LoginByEmail x pass

--- a/thentos-core/schema/schema.sql
+++ b/thentos-core/schema/schema.sql
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS users (
     id         bigserial   PRIMARY KEY,
     name       text        NOT NULL UNIQUE,
-    password   text        NOT NULL,
+    password   bytea       NOT NULL,
     email      text        NOT NULL UNIQUE,
     confirmed  bool        NOT NULL,
     created    timestamptz NOT NULL DEFAULT now()
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS services (
     owner_user    bigint     NOT NULL REFERENCES users (id),
     name          text       NOT NULL,
     description   text       NOT NULL,
-    key           text       NOT NULL
+    key           bytea      NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS service_roles (

--- a/thentos-core/schema/schema.sql
+++ b/thentos-core/schema/schema.sql
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS users (
     id         bigserial   PRIMARY KEY,
     name       text        NOT NULL UNIQUE,
-    password   bytea       NOT NULL,
+    password   text        NOT NULL,
     email      text        NOT NULL UNIQUE,
     confirmed  bool        NOT NULL,
     created    timestamptz NOT NULL DEFAULT now()
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS services (
     owner_user    bigint     NOT NULL REFERENCES users (id),
     name          text       NOT NULL,
     description   text       NOT NULL,
-    key           bytea      NOT NULL
+    key           text       NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS service_roles (

--- a/thentos-core/src/Thentos/Action.hs
+++ b/thentos-core/src/Thentos/Action.hs
@@ -305,7 +305,7 @@ lookupUserCheckPassword_ transaction password = a `catchError` h
   where
     a = do
         (uid, user) <- queryA transaction
-        if verifyPass password user
+        if verifyUserPass password user
             then return (uid, user)
             else throwError BadCredentials
 
@@ -472,7 +472,7 @@ startThentosSessionByServiceId sid key = a `catchError` h
   where
     a = do
         (_, service) <- queryA (T.lookupService sid)
-        unless (verifyKey key service) $ throwError BadCredentials
+        unless (verifyServiceKey key service) $ throwError BadCredentials
         startThentosSessionByAgent_ (ServiceA sid)
 
     h NoSuchService =

--- a/thentos-core/src/Thentos/Backend/Api/Simple.hs
+++ b/thentos-core/src/Thentos/Backend/Api/Simple.hs
@@ -138,8 +138,8 @@ thentosThentosSession =
        startThentosSession
   :<|> existsThentosSession
   :<|> endThentosSession
-  where startThentosSession (ByUser (id', pass)) = startThentosSessionByUserId id' pass
-        startThentosSession (ByService (id', key)) = startThentosSessionByServiceId id' key
+  where startThentosSession (ByUser id' pass) = startThentosSessionByUserId id' pass
+        startThentosSession (ByService id' key) = startThentosSessionByServiceId id' key
 
 
 -- * service session

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -450,19 +450,19 @@ instance Aeson.ToJSON ServiceSessionMetadata where toJSON = Aeson.gtoJson
 instance FromField ServiceSessionMetadata where
     fromField f dat = ServiceSessionMetadata <$> fromField f dat
 
-data ByUserOrServiceId = ByUser (UserId, UserPass)  -- FIXME: @ByUser UserId UserPass@?  (same in next line)
-                       | ByService (ServiceId, ServiceKey)
+data ByUserOrServiceId = ByUser UserId UserPass
+                       | ByService ServiceId ServiceKey
   deriving (Eq, Typeable, Generic)
 
 instance FromJSON ByUserOrServiceId where
     parseJSON (Aeson.Object (H.toList -> [(key, val)]))
-        | key == "user"    = ByUser <$> Aeson.parseJSON val
-        | key == "service" = ByService <$> Aeson.parseJSON val
+        | key == "user"    = uncurry ByUser <$> Aeson.parseJSON val
+        | key == "service" = uncurry ByService <$> Aeson.parseJSON val
     parseJSON bad = aesonError "ByUserOrServiceId" bad
 
 instance ToJSON ByUserOrServiceId where
-    toJSON (ByUser v)    = Aeson.object [ "user" .= Aeson.toJSON v]
-    toJSON (ByService v) = Aeson.object [ "service" .= Aeson.toJSON v]
+    toJSON (ByUser i k)    = Aeson.object [ "user" .= Aeson.toJSON (i, k)]
+    toJSON (ByService i k) = Aeson.object [ "service" .= Aeson.toJSON (i, k)]
 
 
 -- * timestamp, timeout

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TemplateHaskell             #-}
 {-# LANGUAGE ViewPatterns                #-}
 
+{-# OPTIONS_GHC  #-}
+
 module Thentos.Types
     ( JsonTop(..)
     , User(..)
@@ -90,8 +92,8 @@ import Control.Monad (when, unless)
 import Data.Aeson (FromJSON, ToJSON, Value(String), (.=))
 import Data.Aeson.Types (Parser)
 import Data.Attoparsec.ByteString.Char8 (parseOnly)
-import Database.PostgreSQL.Simple.Types (Binary(Binary, fromBinary))
-import Database.PostgreSQL.Simple.FromField (FromField, fromField, ResultError(..), returnError, typeOid)
+import Database.PostgreSQL.Simple.FromField
+    (FromField, fromField, Conversion, ResultError(..), returnError, typeOid)
 import Database.PostgreSQL.Simple.Missing (intervalSeconds)
 import Database.PostgreSQL.Simple.ToField (Action(Plain), ToField, inQuotes, toField)
 import Database.PostgreSQL.Simple.TypeInfo.Static (interval)
@@ -124,7 +126,6 @@ import URI.ByteString (URI, RelativeRef, URIParseError,
 import Web.HttpApiData (parseQueryParam)
 
 import qualified Data.Aeson as Aeson
-import qualified Data.Binary
 import qualified Data.Csv as CSV
 import qualified Data.ByteString as SBS
 import qualified Data.HashMap.Strict as H
@@ -206,13 +207,18 @@ newtype UserPass = UserPass { fromUserPass :: ST }
 data HashedSecret a = BCryptHash SBS | SCryptHash SBS
     deriving (Eq, Show, Generic)
 
-instance Data.Binary.Binary (HashedSecret a)
-
-instance FromField (HashedSecret a) where
-    fromField f dat = Data.Binary.decode . fromBinary <$> fromField f dat
+instance (Typeable a) => FromField (HashedSecret a) where
+    fromField f = maybe (returnError Incompatible f "") parsePrefix
+      where
+        parsePrefix :: SBS -> Conversion (HashedSecret a)
+        parsePrefix s = case SBS.splitAt 2 s of
+            ("S_", h) -> return $ SCryptHash h
+            ("B_", h) -> return $ BCryptHash h
+            _         -> returnError ConversionFailed f ""
 
 instance ToField (HashedSecret a) where
-    toField = toField . Binary . Data.Binary.encode
+    toField (SCryptHash s) = toField $ "S_" <> s
+    toField (BCryptHash s) = toField $ "B_" <> s
 
 newtype UserEmail = UserEmail { userEmailAddress :: EmailAddress }
     deriving (Eq, Ord, Show, Read, Typeable, Generic)

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -104,6 +104,8 @@ library
     , async >=2.0.2 && <2.1
     , attoparsec >=0.13 && <0.14
     , base >=4.8.1.0 && <5
+    , bcrypt >=0.0.7 && <0.1
+    , binary >= 0.7.5 && <0.8
     , blaze-builder >= 0.4.0 && <0.5
     , blaze-html >=0.8.1.0 && <0.9
     , blaze-markup >=0.7 && <0.8

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -105,7 +105,6 @@ library
     , attoparsec >=0.13 && <0.14
     , base >=4.8.1.0 && <5
     , bcrypt >=0.0.7 && <0.1
-    , binary >= 0.7.5 && <0.8
     , blaze-builder >= 0.4.0 && <0.5
     , blaze-html >=0.8.1.0 && <0.9
     , blaze-markup >=0.7 && <0.8

--- a/thentos-tests/bench/Main.hs
+++ b/thentos-tests/bench/Main.hs
@@ -39,7 +39,7 @@ import qualified Network.HTTP.LoadTest.Report as Pronk
 import Thentos.Config (ThentosConfig)
 import Thentos.Action.Types (ActionState(..))
 import Thentos.Types
-    ( UserFormData(UserFormData), UserName(..), UserPass(..), parseUserEmail
+    ( UserFormData(UserFormData), UserName(..), parseUserEmail
     , UserId, ThentosSessionToken(fromThentosSessionToken), UserId(..)
     , ByUserOrServiceId(ByUser)
     )
@@ -88,7 +88,7 @@ getThentosSessionToken :: ThentosConfig -> IO (Maybe ThentosSessionToken)
 getThentosSessionToken cfg = do
     let (Just req_) = makeEndpoint cfg "/thentos_session"
         req = req_
-                { requestBody = RequestBodyLBS $ Aeson.encode (ByUser (godUid, godPass))
+                { requestBody = RequestBodyLBS $ Aeson.encode (ByUser godUid godPass)
                 , method = methodPost
                 }
     m <- newManager tlsManagerSettings
@@ -252,7 +252,7 @@ loginGenTrans cfg (MachineState uid loginState) =
     loginReq =
         (makeRequest cfg Nothing "/thentos_session")
             { method = methodPost
-            , requestBody = RequestBodyLBS $ Aeson.encode (ByUser (uid, UserPass "dummyPassword"))
+            , requestBody = RequestBodyLBS $ Aeson.encode (ByUser uid "dummyPassword")
             }
 
     logout tok = (logoutReq tok, const LoggedOut)

--- a/thentos-tests/src/Thentos/Test/Arbitrary.hs
+++ b/thentos-tests/src/Thentos/Test/Arbitrary.hs
@@ -1,5 +1,7 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FlexibleInstances  #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Thentos.Test.Arbitrary () where
 
@@ -7,7 +9,6 @@ import Data.String.Conversions (cs)
 import LIO.DCLabel (DCLabel(DCLabel), (%%), (/\), (\/), CNF, toCNF)
 import Test.QuickCheck (Arbitrary(..), sized, vectorOf, elements, Gen)
 
-import qualified Data.ByteString as SBS
 import qualified Data.Text as ST
 
 import Thentos.Types
@@ -16,8 +17,11 @@ import Thentos.Test.Config
 import Thentos.Test.Core
 
 
-instance Arbitrary (HashedSecret a) where
-    arbitrary = encryptTestSecret . SBS.pack <$> arbitrary
+instance Arbitrary (HashedSecret UserPass) where
+    arbitrary = encryptTestSecret fromUserPass <$> arbitrary
+
+instance Arbitrary (HashedSecret ServiceKey) where
+    arbitrary = encryptTestSecret fromServiceKey <$> arbitrary
 
 instance Arbitrary DCLabel where
     arbitrary = DCLabel <$> arbitrary <*> arbitrary
@@ -67,6 +71,9 @@ instance Arbitrary UserPass where
         return . UserPass . cs $ pass
       where
         passwordChar = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9']
+
+instance Arbitrary ServiceKey where
+    arbitrary = ServiceKey . fromUserPass <$> arbitrary
 
 instance Arbitrary UserFormData where
     arbitrary = UserFormData <$> arbitrary <*> arbitrary <*> arbitrary

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -105,7 +105,7 @@ thentosTestConfigYaml = YamlString . cs . unlines $
         -- (change this to your like during debugging)
     "" :
     "database:" :
-    "    name: unused" :
+    "    name: thentos_tests" :
     "" :
     "email_templates:" :
     "    account_verification:" :

--- a/thentos-tests/tests/Thentos/ActionSpec.hs
+++ b/thentos-tests/tests/Thentos/ActionSpec.hs
@@ -67,12 +67,18 @@ spec_user = describe "user" $ do
         it "works" $ \sta -> do
             let user = testUsers !! 0
             uid <- runPrivs [RoleAdmin] sta $ addUser (head testUserForms)
-            (uid', user') <- runPrivs [RoleAdmin] sta $ lookupConfirmedUser uid
+
+            Left (ActionErrorThentos NoSuchUser)
+                <- runClearanceE dcBottom sta $ lookupConfirmedUser uid
+            (uid', user')
+                <- runPrivs [RoleAdmin] sta $ lookupConfirmedUser uid
             uid' `shouldBe` uid
-            user' `shouldBe` (userPassword .~ (user' ^. userPassword) $ user)
+            let clearPassword = userPassword .~ (user ^. userPassword)
+                in clearPassword user' `shouldBe` clearPassword user
+
             void . runPrivs [RoleAdmin] sta $ deleteUser uid
             Left (ActionErrorThentos NoSuchUser) <-
-                runClearanceE dcBottom sta $ lookupConfirmedUser uid
+                runPrivsE [RoleAdmin] sta $ lookupConfirmedUser uid
             return ()
 
         it "guarantee that user names are unique" $ \sta -> do

--- a/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
+++ b/thentos-tests/tests/Thentos/Backend/Api/SimpleSpec.hs
@@ -330,7 +330,7 @@ specRest = do
                 response1 <- postDefaultUser its
                 let Right uid = decodeJsonTop $ simpleBody response1
                 response2 <- request "POST" "/thentos_session" hdr $
-                    Aeson.encode $ ByUser (UserId uid, udPassword defaultUserData)
+                    Aeson.encode $ ByUser (UserId uid) (udPassword defaultUserData)
                 request "GET" "/thentos_session/" hdr (simpleBody response2)
                     `shouldRespondWith` "true" { matchStatus = 200 }
 

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -107,7 +107,7 @@ spec_updateSelf = describe "update self" $ do
             fill_ "/user/update_password.new_password2" $ fromUserPass newSelfPass
             click_ "update_password_submit"
         Right (_, usr) <- runVoidedQuery conn $ T.lookupAnyUser selfId
-        usr `shouldSatisfy` verifyPass newSelfPass
+        usr `shouldSatisfy` verifyUserPass newSelfPass
 
     -- FIXME: test failure cases.  same restrictions apply as in
     -- "create_user" and "reset_password" (make sure the check is in

--- a/thentos-tests/tests/Thentos/TransactionSpec.hs
+++ b/thentos-tests/tests/Thentos/TransactionSpec.hs
@@ -9,7 +9,7 @@ import Control.Monad (void)
 import Data.Either (isRight)
 import Data.List (sort)
 import Data.Pool (Pool)
-import Data.String.Conversions (ST, SBS)
+import Data.String.Conversions (ST)
 import Database.PostgreSQL.Simple (Connection, Only(..))
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Test.Hspec (Spec, SpecWith, before, describe, it, shouldBe, shouldReturn, shouldSatisfy)
@@ -260,7 +260,7 @@ changePasswordSpec :: SpecWith (Pool Connection)
 changePasswordSpec = describe "changePassword" $ do
     let user = mkUser "name" "super secret" "me@example.com"
         userId = UserId 111
-        newPass = encryptTestSecret "new"
+        newPass = encryptTestSecret fromUserPass (UserPass "new")
 
     it "changes the password" $ \connPool -> do
         Right _ <- runVoidedQuery connPool $ addUserPrim (Just userId) user True
@@ -1176,8 +1176,8 @@ garbageCollectCaptchasSpec = describe "garbageCollectCaptchas" $ do
 
 -- * Utils
 
-mkUser :: UserName -> SBS -> ST -> User
+mkUser :: UserName -> UserPass -> ST -> User
 mkUser name pass email = User { _userName = name
-                              , _userPassword = encryptTestSecret pass
+                              , _userPassword = encryptTestSecret fromUserPass pass
                               , _userEmail = forceUserEmail email
                               }

--- a/thentos-tests/tests/Thentos/UtilSpec.hs
+++ b/thentos-tests/tests/Thentos/UtilSpec.hs
@@ -28,11 +28,7 @@ spec = describe "Thentos.Util" $ do
     describe "HashedSecret" $ do
         it "has working binary instance." $ do
             let f h = (Data.Binary.decode . Data.Binary.encode) h `shouldBe` h
-            mapM_ f [ BCryptHash ""
-                    , BCryptHash "..."
-                    , SCryptHash ""
-                    , SCryptHash "..."
-                    ]
+            mapM_ f [h s | h <- [BCryptHash, SCryptHash], s <- ["", "...", "„¡33 € – hilfäh!“"]]
 
     describe "UserPass <-> HashedSecret" $ do
         let f p = do
@@ -66,8 +62,6 @@ spec = describe "Thentos.Util" $ do
     -- >>> run('aI0ZUDmx0DVJI')
     -- >>> run('jaDEzQ7MQpN26')
     -- >>> run('„¡33 € – hilfäh!“')
-    --
-    -- Note that the unicode string literal in the last line looks a little different in Haskell.
     describe "bcrypt verification" $ do
         let run (clear :: ST) (hashed :: SBS) = (clear, verdict) `shouldSatisfy` snd
                 where verdict :: Bool = verifyUserPass (UserPass clear) (mkUser (BCryptHash hashed))

--- a/thentos-tests/tests/Thentos/UtilSpec.hs
+++ b/thentos-tests/tests/Thentos/UtilSpec.hs
@@ -71,6 +71,7 @@ spec = describe "Thentos.Util" $ do
     describe "bcrypt verification" $ do
         let run (clear :: ST) (hashed :: SBS) = (clear, verdict) `shouldSatisfy` snd
                 where verdict :: Bool = verifyUserPass (UserPass clear) (mkUser (BCryptHash hashed))
+                                     && verifyServiceKey (ServiceKey clear) (mkService (BCryptHash hashed))
 
             samples = [ ("", "$2a$10$5lEQtZWJ9BglditOGuARrugb8g79hXeMhc7aWtNY5/QowmxEcSnBi")
                       , ("***", "$2a$10$Ktrbw39lib1doqd.hSQ7UOKSkuLYIsUbTrcEsYPofsnrkIsGFCaXW")
@@ -86,6 +87,9 @@ spec = describe "Thentos.Util" $ do
         it "falsifies." $ do
             s <- mkService <$> hashServiceKey "good"
             verifyServiceKey "bad" s `shouldBe` False
+
+            let s' = mkService (BCryptHash "$2a$10$5lEQtZWJ9BglditOGuARrugb8g79hXeMhc7aWtNY5/QowmxEcSnBi")
+            verifyServiceKey "bad" s' `shouldBe` False
 
             u <- mkUser <$> hashUserPass "good"
             verifyUserPass "bad" u `shouldBe` False

--- a/thentos-tests/tests/Thentos/UtilSpec.hs
+++ b/thentos-tests/tests/Thentos/UtilSpec.hs
@@ -81,3 +81,14 @@ spec = describe "Thentos.Util" $ do
                       ]
 
         it "works." $ mapM_ (uncurry run) samples
+
+    describe "bad password" $ do
+        it "falsifies." $ do
+            s <- mkService <$> hashServiceKey "good"
+            verifyServiceKey "bad" s `shouldBe` False
+
+            u <- mkUser <$> hashUserPass "good"
+            verifyUserPass "bad" u `shouldBe` False
+
+            let u' = mkUser (BCryptHash "$2a$10$5lEQtZWJ9BglditOGuARrugb8g79hXeMhc7aWtNY5/QowmxEcSnBi")
+            verifyUserPass "bad" u' `shouldBe` False

--- a/thentos-tests/tests/Thentos/UtilSpec.hs
+++ b/thentos-tests/tests/Thentos/UtilSpec.hs
@@ -8,8 +8,6 @@ module Thentos.UtilSpec where
 import Data.String.Conversions (ST, SBS)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 
-import qualified Data.Binary
-
 import Thentos.Types
 import Thentos.Util
 
@@ -25,11 +23,6 @@ mkService h = Service h (UserId 0) Nothing "name" "description"
 
 spec :: Spec
 spec = describe "Thentos.Util" $ do
-    describe "HashedSecret" $ do
-        it "has working binary instance." $ do
-            let f h = (Data.Binary.decode . Data.Binary.encode) h `shouldBe` h
-            mapM_ f [h s | h <- [BCryptHash, SCryptHash], s <- ["", "...", "„¡33 € – hilfäh!“"]]
-
     describe "UserPass <-> HashedSecret" $ do
         let f p = do
                 h <- hashUserPass p

--- a/thentos-tests/tests/Thentos/UtilSpec.hs
+++ b/thentos-tests/tests/Thentos/UtilSpec.hs
@@ -24,7 +24,7 @@ mkService :: HashedSecret ServiceKey -> Service
 mkService h = Service h (UserId 0) Nothing "name" "description"
 
 spec :: Spec
-spec = describe "UtilSpec" $ do
+spec = describe "Thentos.Util" $ do
     describe "HashedSecret" $ do
         it "has working binary instance." $ do
             let f h = (Data.Binary.decode . Data.Binary.encode) h `shouldBe` h

--- a/thentos-tests/tests/Thentos/UtilSpec.hs
+++ b/thentos-tests/tests/Thentos/UtilSpec.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+
+{-# OPTIONS_GHC  #-}
+
+module Thentos.UtilSpec where
+
+import Data.String.Conversions (ST, SBS)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+import qualified Data.Binary
+
+import Thentos.Types
+import Thentos.Util
+
+import Thentos.Test.Arbitrary ()
+import Thentos.Test.Config (forceUserEmail)
+
+
+mkUser :: HashedSecret UserPass -> User
+mkUser h = User "" h (forceUserEmail "a@b.c")
+
+mkService :: HashedSecret ServiceKey -> Service
+mkService h = Service h (UserId 0) Nothing "name" "description"
+
+spec :: Spec
+spec = describe "UtilSpec" $ do
+    describe "HashedSecret" $ do
+        it "has working binary instance." $ do
+            let f h = (Data.Binary.decode . Data.Binary.encode) h `shouldBe` h
+            mapM_ f [ BCryptHash ""
+                    , BCryptHash "..."
+                    , SCryptHash ""
+                    , SCryptHash "..."
+                    ]
+
+    describe "UserPass <-> HashedSecret" $ do
+        let f p = do
+                h <- hashUserPass p
+                verifyUserPass p (mkUser h) `shouldBe` True
+        it "works." $ do
+            f ""
+            f "..."
+            f "esZ2t/Wos4pNU"
+
+    describe "ServiceKey <-> HashedSecret" $ do
+        let f k = do
+                h <- hashServiceKey k
+                verifyServiceKey k (mkService h) `shouldBe` True
+        it "works." $ do
+            f ""
+            f "..."
+            f "esZ2t/Wos4pNU"
+
+    -- The samples for this test have been generated with the following python script:
+    --
+    -- >>> from cryptacular.bcrypt import BCRYPTPasswordManager
+    -- >>> manager = BCRYPTPasswordManager()
+    -- >>>
+    -- >>> def run(password):
+    -- >>>     print "(" + repr(password) + ", " + repr(manager.encode(password)) + ")"
+    -- >>>
+    -- >>> run('')
+    -- >>> run('***')
+    -- >>> run('Cz3FWh613Dq.I')
+    -- >>> run('aI0ZUDmx0DVJI')
+    -- >>> run('jaDEzQ7MQpN26')
+    -- >>> run('„¡33 € – hilfäh!“')
+    --
+    -- Note that the unicode string literal in the last line looks a little different in Haskell.
+    describe "bcrypt verification" $ do
+        let run (clear :: ST) (hashed :: SBS) = (clear, verdict) `shouldSatisfy` snd
+                where verdict :: Bool = verifyUserPass (UserPass clear) (mkUser (BCryptHash hashed))
+
+            samples = [ ("", "$2a$10$5lEQtZWJ9BglditOGuARrugb8g79hXeMhc7aWtNY5/QowmxEcSnBi")
+                      , ("***", "$2a$10$Ktrbw39lib1doqd.hSQ7UOKSkuLYIsUbTrcEsYPofsnrkIsGFCaXW")
+                      , ("Cz3FWh613Dq.I", "$2a$10$P9XIRAt3BRuJMlWErMJGZOqFqaw57o/SmfmwIW0CI9.Mv.w8EIkLe")
+                      , ("aI0ZUDmx0DVJI", "$2a$10$xohDX.tn1yVoc4Bl5djLQ.L3nMc02mVVj0DNAc88faLNhlKYDB1DC")
+                      , ("jaDEzQ7MQpN26", "$2a$10$ynKapqrChDtvvUuvSi5/teD3oeRW.QMpSawe8TR3qZ9JqDoh2qpii")
+                      , ("„¡33 € – hilfäh!“", "$2a$10$MqxOGleJdX2KszMciuTNVOYWlMv1ae7WzUXHw8iLSAIhd19AFIPgy")
+                      ]
+
+        it "works." $ mapM_ (uncurry run) samples

--- a/thentos-tests/thentos-tests.cabal
+++ b/thentos-tests/thentos-tests.cabal
@@ -101,6 +101,8 @@ test-suite tests
       aeson >=0.8.0.2 && <0.9
     , attoparsec >=0.12.1.6 && <0.14
     , base >=4.8.1.0 && <5
+    , bcrypt >=0.0.7 && <0.1
+    , binary >= 0.7.5 && <0.8
     , blaze-html
     , bytestring
     , case-insensitive >=1

--- a/thentos-tests/thentos-tests.cabal
+++ b/thentos-tests/thentos-tests.cabal
@@ -102,7 +102,6 @@ test-suite tests
     , attoparsec >=0.12.1.6 && <0.14
     , base >=4.8.1.0 && <5
     , bcrypt >=0.0.7 && <0.1
-    , binary >= 0.7.5 && <0.8
     , blaze-html
     , bytestring
     , case-insensitive >=1


### PR DESCRIPTION
Support importing users with `bcrypt`-protected passwords.

- Store `HashedSecret` as `bytea` in DB.
- Change names of `verify*` functions.
- Refactor `hashSecret`, `hashSecretWith`: separate pure code from effects.
- Re-think test case in `ActionSpec`.
- Tests.
