### PR TITLE
Add a stack.yml file

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,74 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.20
+
+# Local packages, usually specified by relative directory name
+packages:
+- thentos-core/
+- thentos-adhocracy/
+- thentos-tests/
+- servant-session/
+- submodules/servant/servant/
+- submodules/servant/servant-blaze/
+- submodules/servant/servant-cassava/
+- submodules/servant/servant-client/
+- submodules/servant/servant-docs/
+- submodules/servant/servant-examples/
+- submodules/servant/servant-foreign/
+- submodules/servant/servant-js/
+- submodules/servant/servant-lucid/
+- submodules/servant/servant-mock/
+- submodules/servant/servant-server/
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+- attoparsec-0.13.0.1
+- diagrams-lib-1.3.0.8
+- configifier-0.0.8
+- control-monad-omega-0.3.1
+- digestive-functors-blaze-0.6.0.6
+- elocrypt-0.4.1
+- engine-io-wai-1.0.5
+- functor-infix-0.0.3
+- http-accept-0.2
+- http-api-data-0.1.1.1
+- linear-1.20.3
+- lio-0.11.5.0
+- memory-0.10
+- bcrypt-0.0.8
+- scrypt-0.5.0
+- servant-0.5
+- servant-blaze-0.5
+- servant-docs-0.5
+- servant-foreign-0.5
+- servant-js-0.5
+- servant-server-0.5
+- servant-session-0.5
+- wai-digestive-functors-0.3
+- wai-util-0.8
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+nix:
+  enable: false
+  packages: [gcc,icu,zlib,postgresql,espeak]

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -101,9 +101,6 @@ library
       aeson >=0.8.0.2 && <0.9
     , aeson-pretty >=0.7.2 && <0.8
     , aeson-utils >=0.3.0.2 && <0.4
-    , asn1-encoding ==0.9.2
-    , asn1-parse ==0.9.1
-    , asn1-types ==0.3.0
     , async >=2.0.2 && <2.1
     , attoparsec >=0.13 && <0.14
     , base >=4.8.1.0 && <5
@@ -126,7 +123,7 @@ library
     , either >=4.4.1 && <4.5
     , elocrypt >=0.4.1 && <0.5
     , email-validate >=2.1.3 && <2.2
-    , errors ==2.0.0
+    , errors >=2.0.0 && <2.1
     , filepath >=1.4.0.0 && <1.5
     , FontyFruity == 0.5.2
     , functor-infix >=0.0.3 && <0.1
@@ -182,8 +179,6 @@ library
     , wai-extra >= 3.0 && <3.1
     , wai-session >=0.3.2 && <0.4
     , warp >=3.1.3 && <3.2
-    , x509 ==1.6.1
-    , x509-validation ==1.6.2
 
 executable thentos
   if flag(with-thentos-executable)


### PR DESCRIPTION
These are not used directly but were added to please Cabal at some point:
  asn1-encoding ==0.9.2
  asn1-parse ==0.9.1
  asn1-types ==0.3.0
  x509 ==1.6.1
  x509-validation ==1.6.2

The Data.EitherR.fmapL is used from the errors package. This relax its
constraints to (>=2.0.0 && <2.1).