### PR TITLE
[Issue #455] Add support for IPv6 addresses in allow_ips configuration

### DIFF
--- a/thentos-core/src/Network/HostAddr.hs
+++ b/thentos-core/src/Network/HostAddr.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Network.HostAddr
+where
+
+import Data.Int (Int32)
+import Network.Socket
+          (SockAddr(SockAddrInet, SockAddrInet6, SockAddrUnix, SockAddrCan),
+           HostAddress, HostAddress6, SocketType(Stream), AddrInfoFlag(AI_NUMERICHOST),
+           addrAddress, getAddrInfo, addrFlags, addrSocketType, defaultHints)
+
+data HostAddr
+    = HostAddress  HostAddress
+    | HostAddress6 HostAddress6
+    | UnixAddress  String
+    | CanAddress   Int32
+    deriving (Eq, Read, Show)
+
+hostAddr :: SockAddr -> HostAddr
+hostAddr = \case
+    SockAddrInet _ ip -> HostAddress ip
+    SockAddrInet6 _ _ ip _ -> HostAddress6 ip
+    SockAddrUnix fp -> UnixAddress fp
+    SockAddrCan i -> CanAddress i
+
+getHostAddr :: String -> IO HostAddr
+getHostAddr name = hostAddr . addrAddress . single <$> getAddrInfo (Just hints) (Just name) Nothing
+  where
+    hints = defaultHints { addrFlags = [AI_NUMERICHOST], addrSocketType = Stream }
+
+    single [x] = x
+    single []  = error "Impossible error: numeric addresses should always resolve"
+    single _   = error "Impossible error: too many results from getAddrInfo should have been ruled out by our `hints`"

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -59,6 +59,7 @@ library
   exposed-modules:
       Database.PostgreSQL.Simple.Missing
     , LIO.Missing
+    , Network.HostAddr
     , Paths.TH
     , Paths_thentos_core__
     , System.Log.Missing

--- a/thentos-tests/tests/Network/HostAddrSpec.hs
+++ b/thentos-tests/tests/Network/HostAddrSpec.hs
@@ -1,0 +1,19 @@
+module Network.HostAddrSpec where
+
+import Test.Hspec (Spec, describe, it, shouldBe, shouldThrow, anyIOException)
+import Network.HostAddr
+
+spec :: Spec
+spec = describe "Network.HostAddr" $ do
+    describe "getHostAddr" $ do
+        let f x y = do
+                h <- getHostAddr x
+                show h `shouldBe` y
+        it "works." $ do
+          f "127.0.0.1" "HostAddress 16777343"
+          f "::1" "HostAddress6 (0,0,0,1)"
+          f "255.255.255.255" "HostAddress 4294967295"
+          f "ff:ff:ff:ff:ff:ff:ff:ff" "HostAddress6 (16711935,16711935,16711935,16711935)"
+          shouldThrow (getHostAddr "1.2.3.4.5") anyIOException
+          shouldThrow (getHostAddr "ff:ff:ff:ff:ff:ff:ff:ff:ff") anyIOException
+          shouldThrow (getHostAddr "example.com") anyIOException

--- a/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
+++ b/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
@@ -136,3 +136,5 @@ specWithBackends = describe "hasPrivilegedIp" $ do
     works ["127.0.0.1"] True
     works ["1.2.3.4"] False
     works [] False
+    works ["::1"] False
+    works ["fe80::42:d4ff:fec0:544d"] False


### PR DESCRIPTION
* Instead of `inet_addr`, use `getAddrInfo` which supports IPv6
* A new module `Network.HostAddr` including:
    * `HostAddr` a type wrapping the different kind of addresses
    * `getHostAddr` a wrapper over `getAddrInfo` returning a `HostAddr`
    * `hostAddr` extract `HostAddr` from a `SockAddr`