### PR TITLE
[Issue #465] Refactoring: _Left subsumes fmapL* functions

### DIFF
--- a/thentos-core/src/Thentos/Action/Core.hs
+++ b/thentos-core/src/Thentos/Action/Core.hs
@@ -10,7 +10,6 @@ import Control.Monad.Reader (runReaderT)
 import Control.Monad.State (runStateT)
 import Control.Monad.Trans.Either (eitherT)
 import Data.Bifunctor (first)
-import Data.EitherR (fmapL)
 import Data.Typeable (Typeable)
 import LIO.Core (LIOState(LIOState), liftLIO, evalLIO, taint, guardWrite)
 import LIO.DCLabel (CNF, DCLabel)
@@ -74,7 +73,7 @@ runActionE polyState actionState action = catchUnknown
           . (`runReaderT` actionState)
           . fromAction
 
-    catchAnyLabelError = (first (fmapL ActionErrorThentos) <$> inner action)
+    catchAnyLabelError = (first (first ActionErrorThentos) <$> inner action)
         `catch` \e -> return (Left $ ActionErrorAnyLabel e, polyState)
 
     catchUnknown = catchAnyLabelError

--- a/thentos-core/src/Thentos/Backend/Core.hs
+++ b/thentos-core/src/Thentos/Backend/Core.hs
@@ -10,7 +10,7 @@
 module Thentos.Backend.Core
 where
 
-import Control.Lens ((^.), (&), (.~), (%~))
+import Control.Lens ((^.), (&), (.~), (%~), _Left)
 import Control.Monad.Trans.Except (ExceptT(ExceptT))
 import Control.Monad (when)
 import Data.Aeson (Value(String), ToJSON(toJSON), (.=), encode, object)
@@ -73,7 +73,7 @@ enterAction polyState actionState toServantErr creds = Nat $ ExceptT . run toSer
     run :: (Show e, Typeable e)
         => (ActionError e -> IO ServantErr)
         -> Action e s a -> IO (Either ServantErr a)
-    run e = (>>= fmapLM e . fst) . runActionE polyState actionState . (updatePrivs creds >>)
+    run e = (>>= _Left e . fst) . runActionE polyState actionState . (updatePrivs creds >>)
 
     updatePrivs :: ThentosAuthCredentials -> Action e s ()
     updatePrivs (ThentosAuthCredentials mTok origin) = f mTok >> (allowedIps >>= g origin)

--- a/thentos-core/src/Thentos/Frontend/State.hs
+++ b/thentos-core/src/Thentos/Frontend/State.hs
@@ -9,6 +9,7 @@ module Thentos.Frontend.State where
 import Control.Monad.Except (throwError, catchError)
 import Control.Monad.Trans.Except (ExceptT(ExceptT))
 import Control.Monad.State (get, gets, put)
+import Control.Lens (_Left)
 import Data.Char (ord)
 import Data.Configifier (Tagged(Tagged), (>>.))
 import Data.Monoid ((<>))
@@ -130,7 +131,7 @@ enterFAction ::
     -> Vault.Key FSession
     -> FSessionMap
     -> FAction :~> ExceptT ServantErr IO
-enterFAction aState key smap = Nat $ ExceptT . (>>= fmapLM fActionServantErr) . run
+enterFAction aState key smap = Nat $ ExceptT . (>>= _Left fActionServantErr) . run
   where
     run :: forall a. FAction a -> IO (Either (ActionError FActionError) a)
     run fServer = fst <$> runActionE emptyFrontendSessionData aState fServer'

--- a/thentos-core/src/Thentos/Frontend/State.hs
+++ b/thentos-core/src/Thentos/Frontend/State.hs
@@ -37,7 +37,6 @@ import Thentos.Backend.Core
 import Thentos.Config
 import Thentos.Frontend.Types
 import Thentos.Types (ThentosSessionToken, ThentosError(OtherError))
-import Thentos.Util
 
 import qualified Thentos.Frontend.Pages as Pages
 import qualified Thentos.Action.Unsafe as U

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -88,7 +88,7 @@ module Thentos.Types
 where
 
 import Control.Exception (Exception)
-import Control.Lens (makeLenses)
+import Control.Lens (makeLenses, _Left, over)
 import Control.Monad.Except (MonadError, throwError, mzero)
 import Control.Monad (when, unless)
 import Data.Aeson (FromJSON, ToJSON, Value(String), (.=), (.:))
@@ -103,7 +103,6 @@ import Database.PostgreSQL.Simple.TypeInfo (typoid)
 import Data.ByteString.Builder (doubleDec)
 import Data.ByteString.Conversion (ToByteString)
 import Data.Char (isAlpha)
-import Data.EitherR (fmapL)
 import Data.Function (on)
 import Data.Maybe (isNothing, fromMaybe)
 import Data.Monoid ((<>))
@@ -668,7 +667,7 @@ newtype RelRef = RelRef { fromRelRef :: RelativeRef }
 
 instance FromHttpApiData RelRef where
     parseQueryParam s = case decodeUtf8' $ cs s of
-        Right r -> fmapL (cs . show) $ RelRef <$> parseRelativeRef laxURIParserOptions (cs r)
+        Right r -> over _Left (cs . show) $ RelRef <$> parseRelativeRef laxURIParserOptions (cs r)
         Left  e -> Left . cs . show $ e
 
 parseUri :: SBS -> Either URIParseError Uri

--- a/thentos-core/src/Thentos/Util.hs
+++ b/thentos-core/src/Thentos/Util.hs
@@ -14,8 +14,6 @@ module Thentos.Util
     , mailEncode
     , cshow
     , readsPrecEnumBoundedShow
-    , fmapLM
-    , fmapLTM
 ) where
 
 import Control.Lens ((^.))
@@ -95,20 +93,3 @@ readsPrecEnumBoundedShow _ s = f [minBound..]
         (s0, s1) -> if s0 == s' then [(x, s1)] else f xs
       where
         s' = show x
-
-
--- | Like 'fmapL' from "Data.EitherR", but with the update of the
--- left value constructed in an impure action.
-fmapLM :: (Monad m, Functor m) => (a -> m b) -> Either a r -> m (Either b r)
-fmapLM trans (Left e) = Left <$> trans e
-fmapLM _ (Right s) = return $ Right s
-
-
--- | Like 'fmapLT' from "Data.EitherR", but with the update of the
--- left value constructed in an impure action.
-fmapLTM :: (Monad m, Functor m) => (a -> m b) -> EitherT a m r -> EitherT b m r
-fmapLTM trans e = EitherT $ do
-    result <- runEitherT e
-    case result of
-        Right r -> return $ Right r
-        Left l -> Left <$> trans l

--- a/thentos-core/src/Thentos/Util.hs
+++ b/thentos-core/src/Thentos/Util.hs
@@ -18,7 +18,6 @@ module Thentos.Util
 
 import Control.Lens ((^.))
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Trans.Either (EitherT(EitherT), runEitherT)
 import Data.String.Conversions (ConvertibleStrings, SBS, ST, cs)
 import Data.Text.Encoding (encodeUtf8)
 import Network.HTTP.Types (urlEncode)

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -126,7 +126,6 @@ library
     , either >=4.4.1 && <4.5
     , elocrypt >=0.4.1 && <0.5
     , email-validate >=2.1.3 && <2.2
-    , errors ==2.0.0
     , filepath >=1.4.0.0 && <1.5
     , FontyFruity == 0.5.2
     , functor-infix >=0.0.3 && <0.1


### PR DESCRIPTION
* Removes the dependency on `errors`
* `fmapL` can be replaced by `over _Left` or `first`
* `fmapLM` can be replaced by `_Left` or `traverseOf _Left`
* `fmapLTM` was no longer used