### PR TITLE
Upgrade configifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ hlint: .phony thentos-core.hlint thentos-tests.hlint thentos-adhocracy.hlint
 # docs for details.
 
 prepare-repl: .phony
-	echo $(SENSEI_ARGS)
+	@echo $(SENSEI_ARGS)
 	cabal sandbox hc-pkg -- unregister --force thentos-adhocracy || true
 	cabal sandbox hc-pkg -- unregister --force thentos-tests || true
 	cabal sandbox hc-pkg -- unregister --force thentos-core || true

--- a/thentos-adhocracy/thentos-adhocracy.cabal
+++ b/thentos-adhocracy/thentos-adhocracy.cabal
@@ -48,7 +48,7 @@ library
     , aeson-pretty >=0.7.2 && <0.8
     , base >=4.8.1.0 && <5
     , case-insensitive >=1.2.0.4 && <1.3
-    , configifier >=0.0.8 && <0.1
+    , configifier >=0.1.0 && <0.2
     , functor-infix >=0.0.3 && <0.1
     , hslogger >=1.2.9 && <1.3
     , http-client >=0.4.22 && <0.5
@@ -115,7 +115,7 @@ test-suite tests
     , base >=4.8.1.0 && <5
     , bytestring >=0.10.6.0 && <0.11
     , case-insensitive >=1.2.0.4 && <1.3
-    , configifier >=0.0.8 && <0.1
+    , configifier
     , containers >=0.5.6.2 && <0.6
     , filepath >=1.4.0.0 && <1.5
     , hspec >=2.1.10 && <2.3

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -34,7 +34,7 @@ import Control.Applicative ((<|>))
 import Control.Exception (throwIO, try)
 import Data.Configifier
     ( (:>), (:*>)((:*>)), (:>:), (>>.), Source
-    , configifyWithDefault, renderConfigFile, docs, defaultSources
+    , configifyWithDefault, renderConfigFile, docs, defaultSources'
     , ToConfigCode, ToConfig, Tagged(Tagged), TaggedM(TaggedM), MaybeO(..), Error
     )
 import Data.Maybe (fromMaybe)
@@ -200,7 +200,7 @@ printConfigUsage = do
 
 
 getConfig :: FilePath -> IO ThentosConfig
-getConfig configFile = defaultSources [configFile] >>= getConfigWithSources
+getConfig configFile = defaultSources' "THENTOS_" [configFile] >>= getConfigWithSources
 
 getConfigWithSources :: [Source] -> IO ThentosConfig
 getConfigWithSources sources = do

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -116,7 +116,7 @@ library
     , case-insensitive >=1.2.0.4 && <1.3
     , cassava >= 0.4.4 && <0.5
     , cond >=0.4 && <0.5
-    , configifier >=0.0.8 && <0.1
+    , configifier >=0.1.0 && <0.2
     , containers >=0.5.6.2 && <0.6
     , cookie >=0.4.1 && <0.5
     , cryptonite >=0.6 && <0.8

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -16,14 +16,13 @@ module Thentos.Test.Config
 where
 
 import Control.Concurrent.MVar (MVar, readMVar, newMVar)
-import Data.Configifier (Source(YamlString, ShellEnv, CommandLine), (>>.), defaultSources')
+import Data.Configifier (Source(YamlString), (>>.), defaultSources')
 import Data.Maybe (fromMaybe)
 import Data.Pool (Pool)
 import Data.Proxy (Proxy(Proxy))
 import Data.String.Conversions (ST, cs)
 import Database.PostgreSQL.Simple (Connection)
 import System.Directory (setCurrentDirectory, getCurrentDirectory)
-import System.Environment (getEnvironment, getArgs)
 import System.IO.Unsafe (unsafePerformIO)
 
 import Thentos.Config hiding (getDefaultUser)

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -16,7 +16,7 @@ module Thentos.Test.Config
 where
 
 import Control.Concurrent.MVar (MVar, readMVar, newMVar)
-import Data.Configifier (Source(YamlString, ShellEnv, CommandLine), (>>.))
+import Data.Configifier (Source(YamlString, ShellEnv, CommandLine), (>>.), defaultSources')
 import Data.Maybe (fromMaybe)
 import Data.Pool (Pool)
 import Data.Proxy (Proxy(Proxy))
@@ -53,10 +53,7 @@ thentosTestConfig' extra =
     getConfigWithSources . (++ extra)
 
 thentosTestConfigSources :: IO [Source]
-thentosTestConfigSources = do
-    e <- getEnvironment
-    a <- getArgs
-    return [thentosTestConfigYaml, ShellEnv e, CommandLine a]
+thentosTestConfigSources = (thentosTestConfigYaml:) <$> defaultSources' "THENTOS_" []
 
 thentosTestConfigYaml :: Source
 thentosTestConfigYaml = YamlString . cs . unlines $

--- a/thentos-tests/thentos-tests.cabal
+++ b/thentos-tests/thentos-tests.cabal
@@ -48,7 +48,7 @@ library
     , base >=4.8.1.0 && <5
     , bytestring >=0.10.6.0 && <0.11
     , case-insensitive >=1.2.0.4 && <1.3
-    , configifier >=0.0.8 && <0.1
+    , configifier >=0.1.0 && <0.2
     , containers >=0.5.6.2 && <0.6
     , cryptonite >=0.6 && <0.8
     , directory >=1.2.2.0 && <1.3
@@ -108,7 +108,7 @@ test-suite tests
     , bytestring
     , case-insensitive >=1
     , cassava
-    , configifier >=0.0.8 && <0.1
+    , configifier >=0.1.0 && <0.2
     , containers >=0.5.6.2 && <0.6
     , cookie >=0.4.1.6 && <4.2
     , digestive-functors
@@ -168,7 +168,7 @@ benchmark load-test
     , attoparsec >=0.12.1.6 && <0.14
     , base >=4.8.1.0 && <5
     , bytestring >=0.10.6.0 && <0.11
-    , configifier >=0.0.8 && <0.1
+    , configifier >=0.1.0 && <0.2
     , functor-infix >=0.0.3 && <0.1
     , http-conduit >=2.1.8 && <2.2
     , http-types >=0.8.6 && <0.9


### PR DESCRIPTION
New feature: shell variables work with prefix `THENTOS_`.