### PR TITLE
Use `cat` instead of `/bin/cat` for sendmail_path

### DIFF
--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -74,7 +74,7 @@ thentosTestConfigYaml = YamlString . cs . unlines $
     "smtp:" :
     "    sender_name: \"Thentos\"" :
     "    sender_address: \"thentos@thentos.org\"" :
-    "    sendmail_path: \"/bin/cat\"" :
+    "    sendmail_path: \"cat\"" :
     "    sendmail_args: [\"-t\"]" :
     "" :
     "proxy:" :


### PR DESCRIPTION
Indeed the command `cat` might be elsewhere as in `NixOS` for instance.