### PR TITLE
Return all rest errors with content-type json

### DIFF
--- a/thentos-core/src/Thentos/Backend/Core.hs
+++ b/thentos-core/src/Thentos/Backend/Core.hs
@@ -365,7 +365,7 @@ addCorsHeaders policy app req respond = app req $
 
 -- FIXME: move this to a module for use both by frontend and backend.
 runWarpWithCfg :: HttpConfig -> Application -> IO ()
-runWarpWithCfg cfg app = runSettings settings $ jsonifyPlainTextErrors app
+runWarpWithCfg cfg = runSettings settings . jsonifyPlainTextErrors
   where
     settings = setPort (cfg >>. (Proxy :: Proxy '["bind_port"]))
              . setHost hostnameHack


### PR DESCRIPTION
Fixes #474. There is still a FIXME in the new code (not sure whether that matters in practice), but at least it covers the intended use case of converting aeson errors to JSON.