### PR TITLE
Refactoring

### DIFF
--- a/thentos-core/src/Control/Monad/Except/Missing.hs
+++ b/thentos-core/src/Control/Monad/Except/Missing.hs
@@ -1,0 +1,9 @@
+module Control.Monad.Except.Missing where
+
+import Control.Monad.Except (MonadError(catchError, throwError))
+import Data.Functor (($>))
+
+finally :: MonadError e m => m a -> m b -> m a
+finally action finalizer = do
+    a <- action `catchError` \e -> finalizer >> throwError e
+    finalizer $> a

--- a/thentos-core/src/Servant/Missing.hs
+++ b/thentos-core/src/Servant/Missing.hs
@@ -60,18 +60,17 @@ instance (HasServer sublayout) => HasServer (FormReqBody :> sublayout) where
           return $ Route env
 
 
--- FIXME: parts of this comment are specific to thentos
--- | There are two form processor functions that are combined in the execution: the
--- digestive-functors part that composes the form payload or a list of errors to be sent back to the
--- browser, and the part that has effects on system and session state.  The first is factored out so
--- it can live in the Safe "Pages" module.  The renderer needs to be an action so it can e.g. flush
--- and render the 'FrontendMsg' queue.
---
+-- | Handle a route of type @'FormH' htm html payload@.  'formAction' is used by digestive-functors
+-- as submit path for the HTML @FORM@ element.  'processor1' constructs the form, either as empty in
+-- response to a @GET@, or displaying validation errors in response to a @POST@.  'processor2'
+-- responds to a @POST@, handles the validated input values, and returns a new page displaying the
+-- result.  Note that the renderer is monadic so that it can have effects (such as e.g. flushing a
+-- message queue in the session state).
 formH :: forall payload m htm html.
      Monad m
   => ST                           -- ^ formAction
-  -> Form html m payload          -- ^ processor I
-  -> (payload -> m html)          -- ^ processor II
+  -> Form html m payload          -- ^ processor1
+  -> (payload -> m html)          -- ^ processor2
   -> (View html -> ST -> m html)  -- ^ renderer
   -> ServerT (FormH htm html payload) m
 formH formAction processor1 processor2 renderer = getH :<|> postH

--- a/thentos-core/src/Servant/Missing.hs
+++ b/thentos-core/src/Servant/Missing.hs
@@ -1,0 +1,86 @@
+-- FIXME: create a package servant-digestive-functors and
+--        choose a different module name.
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Servant.Missing
+  (FormH
+  ,FormReqBody
+  ,formH) where
+
+import Control.Monad.Identity (Identity, runIdentity)
+import Data.Bifunctor (first)
+import Data.Proxy (Proxy(Proxy))
+import Data.String.Conversions (ST)
+import Network.Wai.Parse (Param, parseRequestBody, lbsBackEnd)
+import Network.Wai (Request)
+import Servant ((:<|>)((:<|>)), (:>), ServerT)
+import Servant.Server.Internal (HasServer, Router'(WithRequest), RouteResult(Route),
+                                route, addBodyCheck)
+import Text.Digestive (Env, Form, FormInput(TextInput), View, fromPath, getForm, postForm)
+
+import qualified Servant
+import qualified Data.Text.Encoding as STE
+
+type FormH htm html payload =
+         Servant.Get '[htm] html
+    :<|> FormReqBody :> Servant.Post '[htm] html
+
+data FormReqBody
+
+instance (HasServer sublayout) => HasServer (FormReqBody :> sublayout) where
+  type ServerT (FormReqBody :> sublayout) m = Env Identity -> ServerT sublayout m
+
+  route Proxy subserver = WithRequest $ \request ->
+      route (Proxy :: Proxy sublayout) (addBodyCheck subserver (bodyCheck request))
+    where
+      -- FIXME: honor accept header
+      -- FIXME: file upload.  shouldn't be hard!
+      bodyCheck :: Request -> IO (RouteResult (Env Identity))
+      bodyCheck req = do
+          q :: [Param]
+              <- parseRequestBody lbsBackEnd req >>=
+                  \case (q, []) -> return q
+                        (_, _:_) -> error "servant-digestive-functors: file upload not implemented!"
+
+          let env :: Env Identity
+              env query = return
+                        . map (TextInput . STE.decodeUtf8 . snd)
+                        . filter ((== fromPath query) . fst)
+                        . map (first STE.decodeUtf8)
+                        $ q
+
+          return $ Route env
+
+
+-- FIXME: parts of this comment are specific to thentos
+-- | There are two form processor functions that are combined in the execution: the
+-- digestive-functors part that composes the form payload or a list of errors to be sent back to the
+-- browser, and the part that has effects on system and session state.  The first is factored out so
+-- it can live in the Safe "Pages" module.  The renderer needs to be an action so it can e.g. flush
+-- and render the 'FrontendMsg' queue.
+--
+formH :: forall payload m htm html.
+     Monad m
+  => ST                           -- ^ formAction
+  -> Form html m payload          -- ^ processor I
+  -> (payload -> m html)          -- ^ processor II
+  -> (View html -> ST -> m html)  -- ^ renderer
+  -> ServerT (FormH htm html payload) m
+formH formAction processor1 processor2 renderer = getH :<|> postH
+  where
+    getH = do
+        v <- getForm formAction processor1
+        renderer v formAction
+
+    postH :: Env Identity -> m html
+    postH env = postForm formAction processor1 (\_ -> return $ return . runIdentity . env) >>=
+        \case (_,              Just payload) -> processor2 payload
+              (v :: View html, Nothing)      -> renderer v formAction

--- a/thentos-core/src/Thentos/Action/Types.hs
+++ b/thentos-core/src/Thentos/Action/Types.hs
@@ -1,7 +1,9 @@
 {- Safe -}
 
+{-# LANGUAGE ConstraintKinds             #-}
 {-# LANGUAGE DeriveFunctor               #-}
 {-# LANGUAGE DeriveGeneric               #-}
+{-# LANGUAGE FlexibleContexts            #-}
 {-# LANGUAGE FlexibleInstances           #-}
 {-# LANGUAGE MultiParamTypeClasses       #-}
 {-# LANGUAGE PackageImports              #-}
@@ -82,6 +84,12 @@ instance MonadState s (Action e s) where
 instance MonadLIO DCLabel (Action e s) where
     liftLIO lio = Action . ReaderT $ \_ -> EitherT (Right <$> lift lio)
 
+-- FIXME: use me instead of 'Action'.
+type MonadAction e s m =
+    (MonadReader ActionState m,
+     MonadError (ThentosError e) m,
+     MonadState s m,
+     MonadLIO DCLabel m)
 
 -- | Errors known by 'runActionE', 'runAction', ....
 --

--- a/thentos-core/src/Thentos/Frontend/Handlers.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers.hs
@@ -305,8 +305,8 @@ dashboardH =
 
 -- * services
 
--- (FIXME: the whole way tabs are switched could use a bit more work.)
--- At least switching tab is no factored at a single place.
+-- (FIXME: the whole way tabs are switched could use a bit more work.
+-- At least switching tab is now factored at a single place.)
 switchTab  :: DashboardTab
            -> (FrontendSessionData -> v -> a -> User -> [Group] -> H.Html)
            -> v -> a -> Action FActionError FrontendSessionData H.Html

--- a/thentos-core/src/Thentos/Frontend/Handlers/Combinators.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers/Combinators.hs
@@ -2,7 +2,7 @@
 
 module Thentos.Frontend.Handlers.Combinators where
 
-import Control.Lens ((^.), (%=), (.~), (.=), use, _Just)
+import Control.Lens ((^.), (%=), (.~), (?=), use, _Just)
 import Control.Monad.State.Class (get, gets, state)
 import Data.ByteString.Builder (toLazyByteString)
 import Data.String.Conversions (SBS, ST, cs)
@@ -43,7 +43,7 @@ loggerU = U.logger System.Log.DEBUG . show
 
 -- | If logged in: set current dashboard tab.
 setTab :: DashboardTab -> FAction ()
-setTab t = fsdLogin . _Just . fslDashboardTab .= Just t
+setTab = (fsdLogin . _Just . fslDashboardTab ?=)
 
 -- | Call 'renderDashboard'' to construct a dashboard page and render it in the frontend monad.
 renderDashboard :: (User -> [Group] -> H.Html) -> FAction H.Html

--- a/thentos-core/src/Thentos/Frontend/Handlers/Combinators.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers/Combinators.hs
@@ -2,8 +2,8 @@
 
 module Thentos.Frontend.Handlers.Combinators where
 
-import Control.Lens ((^.), (%~), (.~), _Just)
-import Control.Monad.State.Class (get, gets, modify, state)
+import Control.Lens ((^.), (%=), (.~), (.=), use, _Just)
+import Control.Monad.State.Class (get, gets, state)
 import Data.ByteString.Builder (toLazyByteString)
 import Data.String.Conversions (SBS, ST, cs)
 import Data.Text.Encoding (encodeUtf8)
@@ -43,7 +43,7 @@ loggerU = U.logger System.Log.DEBUG . show
 
 -- | If logged in: set current dashboard tab.
 setTab :: DashboardTab -> FAction ()
-setTab = modify . (fsdLogin . _Just . fslDashboardTab .~) . Just
+setTab t = fsdLogin . _Just . fslDashboardTab .= Just t
 
 -- | Call 'renderDashboard'' to construct a dashboard page and render it in the frontend monad.
 renderDashboard :: (User -> [Group] -> H.Html) -> FAction H.Html
@@ -86,14 +86,14 @@ popServiceLoginState = state $
     \fsd -> (fsd ^. fsdServiceLoginState, fsdServiceLoginState .~ Nothing $ fsd)
 
 getServiceLoginState :: FAction ServiceLoginState
-getServiceLoginState = gets (^. fsdServiceLoginState) >>= maybe err pure
+getServiceLoginState = use fsdServiceLoginState >>= maybe err pure
   where
     err = crash $ FActionError500 "Service login: no state."
 
 sendFrontendMsgs :: [FrontendMsg] -> FAction ()
 sendFrontendMsgs msgs = do
     loggerF msgs
-    modify $ fsdMessages %~ (++ msgs)
+    fsdMessages %= (++ msgs)
 
 sendFrontendMsg :: FrontendMsg -> FAction ()
 sendFrontendMsg = sendFrontendMsgs . (:[])
@@ -104,7 +104,7 @@ clearAllFrontendMsgs = state $ \s -> ((), fsdMessages .~ [] $ s)
 showPageWithMessages :: (FrontendSessionData -> View H.Html -> ST -> H.Html)
     -> View H.Html -> ST -> FAction H.Html
 showPageWithMessages page v a = do
-    html <- (\fsd -> page fsd v a) <$> get
+    html <- gets $ \fsd -> page fsd v a
     clearAllFrontendMsgs
     return html
 

--- a/thentos-core/thentos-core.cabal
+++ b/thentos-core/thentos-core.cabal
@@ -57,11 +57,13 @@ library
   if flag(development)
     cpp-options: -DDEVELOPMENT
   exposed-modules:
-      Database.PostgreSQL.Simple.Missing
+      Control.Monad.Except.Missing
+    , Database.PostgreSQL.Simple.Missing
     , LIO.Missing
     , Network.HostAddr
     , Paths.TH
     , Paths_thentos_core__
+    , Servant.Missing
     , System.Log.Missing
     , Thentos
     , Thentos.Action


### PR DESCRIPTION
* Move `finally` into the new module `Control.Monad.Except.Missing`
* Move `formH` into the new module `Servant.Missing`
* Add a `MonadAction` context synonym to be used instead of some
  occurrences of `Action`
* Use `for_` instead of `mapM_` when this reads better
* Use `$>` instead of `>>` and `return`
* Use `.=` instead of `modify` and `.~`
* Use `%=` instead of `modify` and `%~`
* Use `use` instead of `gets` and `^.`
* Use `preuse` instead of `gets` and a manual version of `^?`
* Factor the tab switching as `switchTab` and `switchTab'`