### PR TITLE
Renaming.

### DIFF
--- a/thentos-adhocracy/devel.config
+++ b/thentos-adhocracy/devel.config
@@ -41,7 +41,7 @@ default_user:
     name: "god"
     password: "god"
     email: "postmaster@localhost"
-    roles: ["roleAdmin", "roleUser", "roleServiceAdmin", "roleUserAdmin"]
+    groups: ["groupAdmin", "groupUser", "groupServiceAdmin", "groupUserAdmin"]
 
 user_reg_expiration: 1d
 pw_reset_expiration: 1d

--- a/thentos-adhocracy/tests/Thentos/Adhocracy3/Backend/Api/SimpleSpec.hs
+++ b/thentos-adhocracy/tests/Thentos/Adhocracy3/Backend/Api/SimpleSpec.hs
@@ -255,7 +255,7 @@ setupBackend' extraCfg = do
     as@(ActionState cfg _ _) <- thentosTestConfig' extraCfg >>= createActionState'
     mgr <- newManager defaultManagerSettings
     createDefaultUser as
-    ((), ()) <- runActionWithPrivs [toCNF RoleAdmin] () as $ autocreateMissingServices cfg
+    ((), ()) <- runActionWithPrivs [toCNF GroupAdmin] () as $ autocreateMissingServices cfg
     let Just beConfig = Tagged <$> cfg >>. (Proxy :: Proxy '["backend"])
     return (serveApi mgr beConfig as, cfg)
 

--- a/thentos-core/devel.config
+++ b/thentos-core/devel.config
@@ -19,7 +19,7 @@ default_user:
     name: "god"
     password: "god"
     email: "postmaster@localhost"
-    roles: ["roleAdmin", "roleUser", "roleServiceAdmin", "roleUserAdmin"]
+    groups: ["groupAdmin", "groupUser", "groupServiceAdmin", "groupUserAdmin"]
 
 user_reg_expiration: 1d
 pw_reset_expiration: 1d

--- a/thentos-core/schema/schema.sql
+++ b/thentos-core/schema/schema.sql
@@ -27,10 +27,10 @@ CREATE TABLE IF NOT EXISTS email_change_tokens (
     new_email  text        NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS user_roles (
-    uid  bigint NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-    role text   NOT NULL,
-    UNIQUE (uid, role)
+CREATE TABLE IF NOT EXISTS user_groups (
+    uid   bigint NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    group text   NOT NULL,
+    UNIQUE (uid, group)
 );
 
 CREATE TABLE IF NOT EXISTS services (
@@ -41,10 +41,10 @@ CREATE TABLE IF NOT EXISTS services (
     key           text       NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS service_roles (
+CREATE TABLE IF NOT EXISTS service_groups (
     sid         text       REFERENCES services (id) ON DELETE CASCADE,
-    role        text       NOT NULL,
-    UNIQUE (sid, role)
+    group       text       NOT NULL,
+    UNIQUE (sid, group)
 );
 
 CREATE TABLE IF NOT EXISTS user_services (

--- a/thentos-core/schema/schema.sql
+++ b/thentos-core/schema/schema.sql
@@ -29,8 +29,8 @@ CREATE TABLE IF NOT EXISTS email_change_tokens (
 
 CREATE TABLE IF NOT EXISTS user_groups (
     uid   bigint NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-    group text   NOT NULL,
-    UNIQUE (uid, group)
+    grp   text   NOT NULL,
+    UNIQUE (uid, grp)
 );
 
 CREATE TABLE IF NOT EXISTS services (
@@ -43,8 +43,8 @@ CREATE TABLE IF NOT EXISTS services (
 
 CREATE TABLE IF NOT EXISTS service_groups (
     sid         text       REFERENCES services (id) ON DELETE CASCADE,
-    group       text       NOT NULL,
-    UNIQUE (sid, group)
+    grp         text       NOT NULL,
+    UNIQUE (sid, grp)
 );
 
 CREATE TABLE IF NOT EXISTS user_services (

--- a/thentos-core/src/Thentos.hs
+++ b/thentos-core/src/Thentos.hs
@@ -63,7 +63,7 @@ makeMain commandSwitch =
 
     _ <- runGcLoop actionState $ config >>. (Proxy :: Proxy '["gc_interval"])
     createDefaultUser actionState
-    _ <- runActionWithPrivs [toCNF RoleAdmin] () actionState
+    _ <- runActionWithPrivs [toCNF GroupAdmin] () actionState
         (autocreateMissingServices config :: Action Void () ())
 
     let mBeConfig :: Maybe HttpConfig
@@ -96,7 +96,7 @@ makeActionState config connPool = do
 runGcLoop :: ActionState -> Maybe Timeout -> IO ThreadId
 runGcLoop _           Nothing         = forkIO $ return ()
 runGcLoop actionState (Just interval) = forkIO . forever $ do
-    _ <- runActionWithPrivs [toCNF RoleAdmin] () actionState (collectGarbage :: Action Void () ())
+    _ <- runActionWithPrivs [toCNF GroupAdmin] () actionState (collectGarbage :: Action Void () ())
     threadDelay $ toMilliseconds interval * 1000
 
 -- | Create a connection pool and initialize the DB by creating all tables, indexes etc. if the DB

--- a/thentos-core/src/Thentos/Action/SimpleAuth.hs
+++ b/thentos-core/src/Thentos/Action/SimpleAuth.hs
@@ -10,7 +10,7 @@ module Thentos.Action.SimpleAuth
   , hasAgent
   , hasUserId
   , hasServiceId
-  , hasRole
+  , hasGroup
   , hasPrivilegedIP
   ) where
 
@@ -38,8 +38,8 @@ hasUserId uid = guardWriteOk (UserA uid %% UserA uid)
 hasServiceId :: ServiceId -> Action e s Bool
 hasServiceId sid = guardWriteOk (ServiceA sid %% ServiceA sid)
 
-hasRole :: Group -> Action e s Bool
-hasRole role = guardWriteOk (role %% role)
+hasGroup :: Group -> Action e s Bool
+hasGroup g = guardWriteOk (g %% g)
 
 hasPrivilegedIP :: Action e s Bool
 hasPrivilegedIP = guardWriteOk (PrivilegedIP %% PrivilegedIP)

--- a/thentos-core/src/Thentos/Action/Unsafe.hs
+++ b/thentos-core/src/Thentos/Action/Unsafe.hs
@@ -55,7 +55,7 @@ extendClearanceOnPrincipals principals = mapM_ extendClearanceOnLabel $ [ p %% p
 extendClearanceOnAgent :: Agent -> Action e s ()
 extendClearanceOnAgent agent = do
     extendClearanceOnPrincipals [agent]
-    unsafeAction (query $ T.agentRoles agent) >>= extendClearanceOnPrincipals
+    unsafeAction (query $ T.agentGroups agent) >>= extendClearanceOnPrincipals
 
 extendClearanceOnThentosSession :: ThentosSessionToken -> Action e s ()
 extendClearanceOnThentosSession tok = do

--- a/thentos-core/src/Thentos/Config.hs
+++ b/thentos-core/src/Thentos/Config.hs
@@ -143,7 +143,7 @@ type DefaultUserConfig' =
             ("name"     :> ST)  -- FIXME: use more specific type?
   :*>       ("password" :> ST)  -- FIXME: use more specific type?
   :*>       ("email"    :> UserEmail)
-  :*> Maybe ("roles"    :> [Group])
+  :*> Maybe ("groups"   :> [Group])
 
 type LogConfig = Tagged (ToConfigCode LogConfig')
 type LogConfig' =
@@ -271,7 +271,7 @@ getUserData cfg = UserFormData
     (cfg >>. (Proxy :: Proxy '["email"]))
 
 getDefaultUser :: DefaultUserConfig -> (UserFormData, [Group])
-getDefaultUser cfg = (getUserData cfg, fromMaybe [] (cfg >>. (Proxy :: Proxy '["roles"])))
+getDefaultUser cfg = (getUserData cfg, fromMaybe [] (cfg >>. (Proxy :: Proxy '["groups"])))
 
 
 -- * logging

--- a/thentos-core/src/Thentos/Frontend/Handlers.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers.hs
@@ -98,8 +98,8 @@ userRegisterH = formH "/user/register" userRegisterForm p (showPageWithMessages 
 type UserRegisterConfirmH = "register_confirm" :>
     QueryParam "token" ConfirmationToken :> Get
 
-defaultUserRoles :: [Group]
-defaultUserRoles = [GroupUser, GroupUserAdmin, GroupServiceAdmin]
+defaultUserGroups :: [Group]
+defaultUserGroups = [GroupUser, GroupUserAdmin, GroupServiceAdmin]
 
 userRegisterConfirmH :: ServerT UserRegisterConfirmH FAction
 userRegisterConfirmH Nothing = crash FActionErrorNoToken
@@ -110,7 +110,7 @@ userRegisterConfirmH (Just token) = do
         loggerF $ "registered new user: " ++ show uid_
         -- FIXME: we need a 'withAccessRights' for things like this.
         U.extendClearanceOnPrincipals [GroupAdmin]
-        for_ defaultUserRoles (assignRole (UserA uid_))
+        for_ defaultUserGroups (assignGroup (UserA uid_))
         return (uid_, sessTok_)
 
     sendFrontendMsg $ FrontendMsgSuccess "Registration complete.  Welcome to Thentos!"

--- a/thentos-core/src/Thentos/Frontend/Handlers.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers.hs
@@ -99,7 +99,7 @@ type UserRegisterConfirmH = "register_confirm" :>
     QueryParam "token" ConfirmationToken :> Get
 
 defaultUserRoles :: [Group]
-defaultUserRoles = [RoleUser, RoleUserAdmin, RoleServiceAdmin]
+defaultUserRoles = [GroupUser, GroupUserAdmin, GroupServiceAdmin]
 
 userRegisterConfirmH :: ServerT UserRegisterConfirmH FAction
 userRegisterConfirmH Nothing = crash FActionErrorNoToken
@@ -109,7 +109,7 @@ userRegisterConfirmH (Just token) = do
         (uid_, sessTok_) <- confirmNewUser token
         loggerF $ "registered new user: " ++ show uid_
         -- FIXME: we need a 'withAccessRights' for things like this.
-        U.extendClearanceOnPrincipals [RoleAdmin]
+        U.extendClearanceOnPrincipals [GroupAdmin]
         for_ defaultUserRoles (assignRole (UserA uid_))
         return (uid_, sessTok_)
 

--- a/thentos-core/src/Thentos/Frontend/Handlers/Combinators.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers/Combinators.hs
@@ -54,9 +54,9 @@ renderDashboard' :: (User -> [Group] -> FAction H.Html) -> FAction H.Html
 renderDashboard' pageletBuilder = do
     runAsUserOrLogin $ \fsd sessionLoginData -> do
         (uid, user) <- lookupConfirmedUser (sessionLoginData ^. fslUserId)
-        roles       <- agentRoles (UserA uid)
+        groups      <- agentGroups (UserA uid)
         clearAllFrontendMsgs
-        dashboardPagelet fsd roles <$> pageletBuilder user roles
+        dashboardPagelet fsd groups <$> pageletBuilder user groups
 
 
 -- * authentication

--- a/thentos-core/src/Thentos/Frontend/Pages.hs
+++ b/thentos-core/src/Thentos/Frontend/Pages.hs
@@ -103,7 +103,7 @@ csrfProofForm _ v action = form v action . (<> csrfField)
 -- caller's responsibility to make sure that dashboard state and body
 -- correspond.
 dashboardPagelet :: FrontendSessionData -> [Group] -> Html -> Html
-dashboardPagelet fsd availableRoles body =
+dashboardPagelet fsd availableGroups body =
     basePagelet fsd "Thentos Dashboard" $ do
         H.div . H.table . H.tr $ mapM_ tabLink [minBound..]
         H.div H.! A.class_ "dashboard_body" $ body
@@ -114,7 +114,7 @@ dashboardPagelet fsd availableRoles body =
             H.td $ H.div ! A.class_ className $ H.a ! A.href urlt $ linkt
       where
         available :: Bool
-        available = all (`elem` availableRoles) (needsRoles tab)
+        available = all (`elem` availableGroups) (needsGroups tab)
 
         className :: H.AttributeValue
         className = if ((fsd ^. fsdLogin) >>= (^. fslDashboardTab)) == Just tab
@@ -127,12 +127,12 @@ dashboardPagelet fsd availableRoles body =
         urlt :: H.AttributeValue
         urlt = H.textValue $ linkUrl tab
 
-    needsRoles :: DashboardTab -> [Group]
-    needsRoles DashboardTabDetails = []
-    needsRoles DashboardTabServices = [GroupUser]
-    needsRoles DashboardTabOwnServices = [GroupServiceAdmin]
-    needsRoles DashboardTabUsers = [GroupUserAdmin]
-    needsRoles DashboardTabLogout = []
+    needsGroups :: DashboardTab -> [Group]
+    needsGroups DashboardTabDetails = []
+    needsGroups DashboardTabServices = [GroupUser]
+    needsGroups DashboardTabOwnServices = [GroupServiceAdmin]
+    needsGroups DashboardTabUsers = [GroupUserAdmin]
+    needsGroups DashboardTabLogout = []
 
     linkText :: DashboardTab -> ST
     linkText DashboardTabDetails     = "details"

--- a/thentos-core/src/Thentos/Frontend/Pages.hs
+++ b/thentos-core/src/Thentos/Frontend/Pages.hs
@@ -129,9 +129,9 @@ dashboardPagelet fsd availableRoles body =
 
     needsRoles :: DashboardTab -> [Group]
     needsRoles DashboardTabDetails = []
-    needsRoles DashboardTabServices = [RoleUser]
-    needsRoles DashboardTabOwnServices = [RoleServiceAdmin]
-    needsRoles DashboardTabUsers = [RoleUserAdmin]
+    needsRoles DashboardTabServices = [GroupUser]
+    needsRoles DashboardTabOwnServices = [GroupServiceAdmin]
+    needsRoles DashboardTabUsers = [GroupUserAdmin]
     needsRoles DashboardTabLogout = []
 
     linkText :: DashboardTab -> ST

--- a/thentos-core/src/Thentos/Transaction.hs
+++ b/thentos-core/src/Thentos/Transaction.hs
@@ -470,44 +470,44 @@ endServiceSession token =
     checkUnique NoSuchServiceSession "endServiceSession: multiple service sessions with same token"
 
 
--- * agents and roles
+-- * agents and groups
 
--- | Add a new role to the roles defined for an 'Agent'.  If 'Group' is already assigned to
+-- | Add a new group to the groups defined for an 'Agent'.  If 'Group' is already assigned to
 -- 'Agent', do nothing.
-assignRole :: Agent -> Group -> ThentosQuery e ()
-assignRole agent role = case agent of
+assignGroup :: Agent -> Group -> ThentosQuery e ()
+assignGroup agent group = case agent of
     ServiceA sid -> catchViolation catcher' $
-        void $ execT [sql| INSERT INTO service_roles (sid, role)
-                           VALUES (?, ?) |] (sid, role)
+        void $ execT [sql| INSERT INTO service_groups (sid, group)
+                           VALUES (?, ?) |] (sid, group)
     UserA uid  -> do
         catchViolation catcher' $ void $
-            execT [sql| INSERT INTO user_roles (uid, role)
-                        VALUES (?, ?) |] (uid, role)
+            execT [sql| INSERT INTO user_groups (uid, group)
+                        VALUES (?, ?) |] (uid, group)
   where
-    catcher' _ (UniqueViolation "user_roles_uid_role_key") = return ()
-    catcher' _ (UniqueViolation "service_roles_sid_role_key") = return ()
+    catcher' _ (UniqueViolation "user_groups_uid_group_key") = return ()
+    catcher' _ (UniqueViolation "service_groups_sid_group_key") = return ()
     catcher' e _                                           = throwIO e
 
--- | Remove a 'Group' from the roles defined for an 'Agent'.  If 'Group' is not assigned to 'Agent',
+-- | Remove a 'Group' from the groups defined for an 'Agent'.  If 'Group' is not assigned to 'Agent',
 -- do nothing.
-unassignRole :: Agent -> Group -> ThentosQuery e ()
-unassignRole agent role = case agent of
+unassignGroup :: Agent -> Group -> ThentosQuery e ()
+unassignGroup agent group = case agent of
     ServiceA sid -> void $ execT
-        [sql| DELETE FROM service_roles WHERE sid = ? AND role = ? |] (sid, role)
+        [sql| DELETE FROM service_groups WHERE sid = ? AND group = ? |] (sid, group)
     UserA uid  -> do
-        void $ execT [sql| DELETE FROM user_roles WHERE uid = ? AND role = ? |]
-                           (uid, role)
+        void $ execT [sql| DELETE FROM user_groups WHERE uid = ? AND group = ? |]
+                           (uid, group)
 
--- | All 'Group's of an 'Agent'.  If 'Agent' does not exist or has no roles, return an empty list.
-agentRoles :: Agent -> ThentosQuery e [Group]
-agentRoles agent = case agent of
+-- | All 'Group's of an 'Agent'.  If 'Agent' does not exist or has no groups, return an empty list.
+agentGroups :: Agent -> ThentosQuery e [Group]
+agentGroups agent = case agent of
     ServiceA sid -> do
-        roles <- queryT [sql| SELECT role FROM service_roles WHERE sid = ? |]
+        groups <- queryT [sql| SELECT group FROM service_groups WHERE sid = ? |]
                         (Only sid)
-        return $ map fromOnly roles
+        return $ map fromOnly groups
     UserA uid  -> do
-        roles <- queryT [sql| SELECT role FROM user_roles WHERE uid = ? |] (Only uid)
-        return $ map fromOnly roles
+        groups <- queryT [sql| SELECT group FROM user_groups WHERE uid = ? |] (Only uid)
+        return $ map fromOnly groups
 
 
 -- * Sybil attack prevention

--- a/thentos-core/src/Thentos/Transaction.hs
+++ b/thentos-core/src/Thentos/Transaction.hs
@@ -477,36 +477,36 @@ endServiceSession token =
 assignGroup :: Agent -> Group -> ThentosQuery e ()
 assignGroup agent group = case agent of
     ServiceA sid -> catchViolation catcher' $
-        void $ execT [sql| INSERT INTO service_groups (sid, group)
+        void $ execT [sql| INSERT INTO service_groups (sid, grp)
                            VALUES (?, ?) |] (sid, group)
     UserA uid  -> do
         catchViolation catcher' $ void $
-            execT [sql| INSERT INTO user_groups (uid, group)
+            execT [sql| INSERT INTO user_groups (uid, grp)
                         VALUES (?, ?) |] (uid, group)
   where
-    catcher' _ (UniqueViolation "user_groups_uid_group_key") = return ()
-    catcher' _ (UniqueViolation "service_groups_sid_group_key") = return ()
-    catcher' e _                                           = throwIO e
+    catcher' _ (UniqueViolation "user_groups_uid_grp_key")    = return ()
+    catcher' _ (UniqueViolation "service_groups_sid_grp_key") = return ()
+    catcher' e _                                              = throwIO e
 
 -- | Remove a 'Group' from the groups defined for an 'Agent'.  If 'Group' is not assigned to 'Agent',
 -- do nothing.
 unassignGroup :: Agent -> Group -> ThentosQuery e ()
 unassignGroup agent group = case agent of
     ServiceA sid -> void $ execT
-        [sql| DELETE FROM service_groups WHERE sid = ? AND group = ? |] (sid, group)
+        [sql| DELETE FROM service_groups WHERE sid = ? AND grp = ? |] (sid, group)
     UserA uid  -> do
-        void $ execT [sql| DELETE FROM user_groups WHERE uid = ? AND group = ? |]
+        void $ execT [sql| DELETE FROM user_groups WHERE uid = ? AND grp = ? |]
                            (uid, group)
 
 -- | All 'Group's of an 'Agent'.  If 'Agent' does not exist or has no groups, return an empty list.
 agentGroups :: Agent -> ThentosQuery e [Group]
 agentGroups agent = case agent of
     ServiceA sid -> do
-        groups <- queryT [sql| SELECT group FROM service_groups WHERE sid = ? |]
+        groups <- queryT [sql| SELECT grp FROM service_groups WHERE sid = ? |]
                         (Only sid)
         return $ map fromOnly groups
     UserA uid  -> do
-        groups <- queryT [sql| SELECT group FROM user_groups WHERE uid = ? |] (Only uid)
+        groups <- queryT [sql| SELECT grp FROM user_groups WHERE uid = ? |] (Only uid)
         return $ map fromOnly groups
 
 

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -658,21 +658,21 @@ instance ToJSON Agent where toJSON = Aeson.gtoJson
 
 -- | Thentos-internal authorization classes.  (See 'ServiceGroup' for service-side authorization classes.)
 data Group =
-    RoleAdmin
+    GroupAdmin
     -- ^ Can do anything.  (There may be no difference in behaviour from 'allowEverything'
     -- resp. 'thentosPublic', but if we ever want to restrict privileges, it's easier if it is a
     -- 'Group'.)
 
-  | RoleUser
+  | GroupUser
     -- ^ Can sign up with services
 
-  | RoleUserAdmin
+  | GroupUserAdmin
     -- ^ Can create (and manage her own) users
 
-  | RoleServiceAdmin
+  | GroupServiceAdmin
     -- ^ Can create (and manage her own) services
 
-  | RoleGroupAdmin
+  | GroupGroupAdmin
     -- ^ Can add personas and groups to groups and remove them
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Generic)
 

--- a/thentos-core/src/Thentos/Types.hs
+++ b/thentos-core/src/Thentos/Types.hs
@@ -645,7 +645,7 @@ instance ToJSON Timeout
     toJSON = Aeson.toJSON . timeoutToString
 
 
--- * role, agent, lio
+-- * group, agent, lio
 
 -- | Some thing or body that deals with (and can authenticate itself before) thentos.  Examples:
 -- 'User' or 'Service'.  (We could have called this 'Principal', but that name is in use by LIO

--- a/thentos-tests/src/Thentos/Test/Config.hs
+++ b/thentos-tests/src/Thentos/Test/Config.hs
@@ -85,7 +85,7 @@ thentosTestConfigYaml = YamlString . cs . unlines $
     "    name: \"god\"" :
     "    password: \"god\"" :
     "    email: \"postmaster@localhost\"" :
-    "    roles: [\"roleAdmin\", \"roleUser\", \"roleServiceAdmin\", \"roleUserAdmin\"]" :
+    "    groups: [\"groupAdmin\", \"groupUser\", \"groupServiceAdmin\", \"groupUserAdmin\"]" :
     "" :
     "user_reg_expiration: 30m" :
     "pw_reset_expiration: 30m" :

--- a/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
+++ b/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
@@ -46,11 +46,11 @@ spec = do
 type Act = Action (ActionError Void) ()
 
 setTwoRoles :: Action e s ()
-setTwoRoles = extendClearanceOnPrincipals [RoleAdmin, RoleUser]
+setTwoRoles = extendClearanceOnPrincipals [GroupAdmin, GroupUser]
 
 setClearanceUid :: Integer -> Action e s ()
 setClearanceUid uid = extendClearanceOnPrincipals [UserA $ UserId uid]
-                   >> extendClearanceOnPrincipals [RoleUser]
+                   >> extendClearanceOnPrincipals [GroupUser]
 
 setClearanceSid :: Integer -> Action e s ()
 setClearanceSid sid = extendClearanceOnPrincipals [ServiceA . ServiceId . cs . show $ sid]
@@ -99,13 +99,13 @@ specWithActionState = before mkActionState $ do
 
     describe "hasRole" $ do
         it "returns True if role is present" $ \sta -> do
-            (True, ()) <- runAction () sta (setClearanceUid 3 >> hasRole RoleUser :: Act Bool)
-            (True, ()) <- runAction () sta (setClearanceUid 5 >> hasRole RoleUser :: Act Bool)
-            (True, ()) <- runAction () sta (setTwoRoles >> hasRole RoleUser :: Act Bool)
+            (True, ()) <- runAction () sta (setClearanceUid 3 >> hasRole GroupUser :: Act Bool)
+            (True, ()) <- runAction () sta (setClearanceUid 5 >> hasRole GroupUser :: Act Bool)
+            (True, ()) <- runAction () sta (setTwoRoles >> hasRole GroupUser :: Act Bool)
             return ()
         it "returns False if role is missing" $ \sta -> do
-            (False, ()) <- runAction () sta (hasRole RoleUser :: Act Bool)
-            (False, ()) <- runAction () sta (setTwoRoles >> hasRole RoleServiceAdmin :: Act Bool)
+            (False, ()) <- runAction () sta (hasRole GroupUser :: Act Bool)
+            (False, ()) <- runAction () sta (setTwoRoles >> hasRole GroupServiceAdmin :: Act Bool)
             return ()
 
 

--- a/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
+++ b/thentos-tests/tests/Thentos/Action/SimpleAuthSpec.hs
@@ -45,8 +45,8 @@ spec = do
 
 type Act = Action (ActionError Void) ()
 
-setTwoRoles :: Action e s ()
-setTwoRoles = extendClearanceOnPrincipals [GroupAdmin, GroupUser]
+setTwoGroups :: Action e s ()
+setTwoGroups = extendClearanceOnPrincipals [GroupAdmin, GroupUser]
 
 setClearanceUid :: Integer -> Action e s ()
 setClearanceUid uid = extendClearanceOnPrincipals [UserA $ UserId uid]
@@ -97,15 +97,15 @@ specWithActionState = before mkActionState $ do
                 (setClearanceUid 3 >> hasServiceId (ServiceId "3") :: Act Bool)
             return ()
 
-    describe "hasRole" $ do
-        it "returns True if role is present" $ \sta -> do
-            (True, ()) <- runAction () sta (setClearanceUid 3 >> hasRole GroupUser :: Act Bool)
-            (True, ()) <- runAction () sta (setClearanceUid 5 >> hasRole GroupUser :: Act Bool)
-            (True, ()) <- runAction () sta (setTwoRoles >> hasRole GroupUser :: Act Bool)
+    describe "hasGroup" $ do
+        it "returns True if group is present" $ \sta -> do
+            (True, ()) <- runAction () sta (setClearanceUid 3 >> hasGroup GroupUser :: Act Bool)
+            (True, ()) <- runAction () sta (setClearanceUid 5 >> hasGroup GroupUser :: Act Bool)
+            (True, ()) <- runAction () sta (setTwoGroups >> hasGroup GroupUser :: Act Bool)
             return ()
-        it "returns False if role is missing" $ \sta -> do
-            (False, ()) <- runAction () sta (hasRole GroupUser :: Act Bool)
-            (False, ()) <- runAction () sta (setTwoRoles >> hasRole GroupServiceAdmin :: Act Bool)
+        it "returns False if group is missing" $ \sta -> do
+            (False, ()) <- runAction () sta (hasGroup GroupUser :: Act Bool)
+            (False, ()) <- runAction () sta (setTwoGroups >> hasGroup GroupServiceAdmin :: Act Bool)
             return ()
 
 

--- a/thentos-tests/tests/Thentos/ActionSpec.hs
+++ b/thentos-tests/tests/Thentos/ActionSpec.hs
@@ -61,7 +61,7 @@ spec = do
     describe "Thentos.Action" . around b $ do
         spec_user
         spec_service
-        spec_agentsAndRoles
+        spec_agentsAndGroups
         spec_session
         spec_captcha
 
@@ -278,35 +278,35 @@ spec_service = describe "service" $ do
             allSids' <- runPrivs [GroupAdmin] sta allServiceIds
             allSids `shouldBe` allSids'
 
-spec_agentsAndRoles :: SpecWith ActionState
-spec_agentsAndRoles = describe "agentsAndRoles" $ do
-    describe "agents and roles" $ do
+spec_agentsAndGroups :: SpecWith ActionState
+spec_agentsAndGroups = describe "agentsAndGroups" $ do
+    describe "agents and groups" $ do
         describe "assign" $ do
             it "can be called by admins" $ \sta -> do
                 [(UserA -> targetAgent, _, _)] <- createTestUsers (sta ^. aStDb) 1
-                result <- runPrivsE [GroupAdmin] sta $ assignRole targetAgent GroupAdmin
+                result <- runPrivsE [GroupAdmin] sta $ assignGroup targetAgent GroupAdmin
                 result `shouldSatisfy` isRight
 
             it "can NOT be called by any non-admin agents" $ \sta -> do
                 [(UserA -> targetAgent, _, _)] <- createTestUsers (sta ^. aStDb) 1
-                result <- runPrivsE [targetAgent] sta $ assignRole targetAgent GroupAdmin
+                result <- runPrivsE [targetAgent] sta $ assignGroup targetAgent GroupAdmin
                 result `shouldSatisfy` isLeft
 
         describe "lookup" $ do
             it "can be called by admins" $ \sta -> do
                 let targetAgent = UserA $ UserId 1
-                result <- runPrivsE [GroupAdmin] sta $ agentRoles targetAgent
+                result <- runPrivsE [GroupAdmin] sta $ agentGroups targetAgent
                 result `shouldSatisfy` isRight
 
-            it "can be called by user for her own roles" $ \sta -> do
+            it "can be called by user for her own groups" $ \sta -> do
                 let targetAgent = UserA $ UserId 1
-                result <- runPrivsE [targetAgent] sta $ agentRoles targetAgent
+                result <- runPrivsE [targetAgent] sta $ agentGroups targetAgent
                 result `shouldSatisfy` isRight
 
             it "can NOT be called by other users" $ \sta -> do
                 let targetAgent = UserA $ UserId 1
                     askingAgent = UserA $ UserId 2
-                result <- runPrivsE [askingAgent] sta $ agentRoles targetAgent
+                result <- runPrivsE [askingAgent] sta $ agentGroups targetAgent
                 result `shouldSatisfy` isLeft
 
 

--- a/thentos-tests/tests/Thentos/ActionSpec.hs
+++ b/thentos-tests/tests/Thentos/ActionSpec.hs
@@ -71,19 +71,19 @@ spec_user = describe "user" $ do
     describe "addUser, lookupConfirmedUser, deleteUser" $ do
         it "works" $ \sta -> do
             let (userForm:_) = testUserForms
-            uid <- runPrivs [RoleAdmin] sta $ addUser userForm
+            uid <- runPrivs [GroupAdmin] sta $ addUser userForm
 
             Left (ActionErrorThentos NoSuchUser)
                 <- runClearanceE dcBottom sta $ lookupConfirmedUser uid
             (uid', user')
-                <- runPrivs [RoleAdmin] sta $ lookupConfirmedUser uid
+                <- runPrivs [GroupAdmin] sta $ lookupConfirmedUser uid
             uid' `shouldBe` uid
             let clearPassword = userPassword .~ testHashedUserPass
                 in clearPassword user' `shouldBe` clearPassword (mkUser userForm)
 
-            void . runPrivs [RoleAdmin] sta $ deleteUser uid
+            void . runPrivs [GroupAdmin] sta $ deleteUser uid
             Left (ActionErrorThentos NoSuchUser) <-
-                runPrivsE [RoleAdmin] sta $ lookupConfirmedUser uid
+                runPrivsE [GroupAdmin] sta $ lookupConfirmedUser uid
             return ()
 
         it "guarantee that user names are unique" $ \sta -> do
@@ -91,7 +91,7 @@ spec_user = describe "user" $ do
             let userFormData = UserFormData (user ^. userName)
                                             (UserPass "foo")
                                             (forceUserEmail "new@one.com")
-            Left (ActionErrorThentos e) <- runPrivsE [RoleAdmin] sta $
+            Left (ActionErrorThentos e) <- runPrivsE [GroupAdmin] sta $
                 addUser userFormData
             e `shouldBe` UserNameAlreadyExists
 
@@ -100,7 +100,7 @@ spec_user = describe "user" $ do
             let userFormData = UserFormData (UserName "newOne")
                                             (UserPass "foobar")
                                             (user ^. userEmail)
-            Left (ActionErrorThentos e) <- runPrivsE [RoleAdmin] sta $ addUser userFormData
+            Left (ActionErrorThentos e) <- runPrivsE [GroupAdmin] sta $ addUser userFormData
             e `shouldBe` UserEmailAlreadyExists
 
     describe "addUnconfirmedUserWithCaptcha" $ do
@@ -135,7 +135,7 @@ spec_user = describe "user" $ do
                 _ <- createCaptcha sta
                 let userCreationRequest = UserCreationRequest userData captchaSolution
                     captchaSolution = CaptchaSolution (CaptchaId "cid") "secret"
-                Right _ <- runPrivsE [RoleAdmin] sta $ addUnconfirmedUserWithCaptcha userCreationRequest
+                Right _ <- runPrivsE [GroupAdmin] sta $ addUnconfirmedUserWithCaptcha userCreationRequest
                 True <- aliceExists sta
                 checkSignupLog sta CaptchaCorrect
 
@@ -144,7 +144,7 @@ spec_user = describe "user" $ do
                 let userCreationRequest = UserCreationRequest userData captchaSolution
                     captchaSolution = CaptchaSolution (CaptchaId "cid") "wrong"
                 Left (ActionErrorThentos InvalidCaptchaSolution) <-
-                    runPrivsE [RoleAdmin] sta $ addUnconfirmedUserWithCaptcha userCreationRequest
+                    runPrivsE [GroupAdmin] sta $ addUnconfirmedUserWithCaptcha userCreationRequest
                 False <- aliceExists sta
                 checkSignupLog sta CaptchaIncorrect
 
@@ -169,7 +169,7 @@ spec_user = describe "user" $ do
         it "changes user email after change request" $ \sta -> do
             let newEmail = forceUserEmail "changed@example.com"
                 checkEmail uid p = do
-                    (_, user) <- runPrivs [RoleAdmin] sta $ lookupConfirmedUser uid
+                    (_, user) <- runPrivs [GroupAdmin] sta $ lookupConfirmedUser uid
                     user ^. userEmail `shouldSatisfy` p
             [(uid, _, _)] <- createTestUsers (sta ^. aStDb) 1
             checkEmail uid $ not . (==) newEmail
@@ -184,7 +184,7 @@ spec_user = describe "user" $ do
         context "if user exists" $ do
             it "sends email with PasswordResetToken and stores token" $ \sta -> do
                 let userData = head testUserForms
-                uid <- runPrivs [RoleAdmin] sta $ addUser userData
+                uid <- runPrivs [GroupAdmin] sta $ addUser userData
                 void . runWithoutPrivs sta . sendPasswordResetMail Nothing . udEmail $ userData
                 [Only token] <- doQuery (sta ^. aStDb)
                     [sql| SELECT token FROM password_reset_tokens WHERE uid = ?|] (Only uid)
@@ -203,7 +203,7 @@ spec_user = describe "user" $ do
             it "changes password, logs user in, deletes token" $ \sta -> do
                 let userData = head testUserForms
                     email    = udEmail userData
-                uid <- runPrivs [RoleAdmin] sta $ addUser userData
+                uid <- runPrivs [GroupAdmin] sta $ addUser userData
                 resetTok <- snd <$> runWithoutPrivs sta (addPasswordResetToken email)
                 void . runWithoutPrivs sta $ resetPasswordAndLogin resetTok "newpass"
                 rowCountShouldBe (sta ^. aStDb) "password_reset_tokens" 0
@@ -221,7 +221,7 @@ spec_user = describe "user" $ do
             it "fails with PasswordTooShort" $ \sta -> do
                 let userData = head testUserForms
                     email    = udEmail userData
-                void . runPrivs [RoleAdmin] sta $ addUser userData
+                void . runPrivs [GroupAdmin] sta $ addUser userData
                 resetTok <- snd <$> runWithoutPrivs sta (addPasswordResetToken email)
                 Left (ActionErrorThentos err) <-
                     runClearanceE dcBottom sta $ resetPasswordAndLogin resetTok "short"
@@ -250,32 +250,32 @@ spec_service = describe "service" $ do
                     $ addService godUid name desc
             Right (service1_id, _s1_key) <- addsvc "fake name" "fake description"
             Right (service2_id, _s2_key) <- addsvc "different name" "different description"
-            service1 <- runPrivs [RoleAdmin] sta $ lookupService service1_id
-            service2 <- runPrivs [RoleAdmin] sta $ lookupService service2_id
+            service1 <- runPrivs [GroupAdmin] sta $ lookupService service1_id
+            service2 <- runPrivs [GroupAdmin] sta $ lookupService service2_id
             service1 `shouldBe` service1 -- sanity check for reflexivity of Eq
             service1 `shouldSatisfy` (/= service2) -- should have different keys
-            void . runPrivs [RoleAdmin] sta $ deleteService service1_id
+            void . runPrivs [GroupAdmin] sta $ deleteService service1_id
             Left (ActionErrorThentos NoSuchService) <-
-                runPrivsE [RoleAdmin] sta $ lookupService service1_id
+                runPrivsE [GroupAdmin] sta $ lookupService service1_id
             return ()
 
     describe "autocreateServiceIfMissing" $ do
         it "adds service if missing" $ \sta -> do
             (godUid, _, _) <- getDefaultUser (sta ^. aStConfig) (sta ^. aStDb)
-            sid <- runPrivs [RoleAdmin] sta $ freshServiceId
-            allSids <- runPrivs [RoleAdmin] sta allServiceIds
+            sid <- runPrivs [GroupAdmin] sta $ freshServiceId
+            allSids <- runPrivs [GroupAdmin] sta allServiceIds
             allSids `shouldNotContain` [sid]
-            runPrivs [RoleAdmin] sta $ autocreateServiceIfMissing godUid sid
-            allSids' <- runPrivs [RoleAdmin] sta allServiceIds
+            runPrivs [GroupAdmin] sta $ autocreateServiceIfMissing godUid sid
+            allSids' <- runPrivs [GroupAdmin] sta allServiceIds
             allSids' `shouldContain` [sid]
 
         it "does nothing if service exists" $ \sta -> do
             (godUid, _, _) <- getDefaultUser (sta ^. aStConfig) (sta ^. aStDb)
-            (sid, _) <- runPrivs [RoleAdmin] sta
+            (sid, _) <- runPrivs [GroupAdmin] sta
                             $ addService godUid "fake name" "fake description"
-            allSids <- runPrivs [RoleAdmin] sta allServiceIds
-            runPrivs [RoleAdmin] sta $ autocreateServiceIfMissing godUid sid
-            allSids' <- runPrivs [RoleAdmin] sta allServiceIds
+            allSids <- runPrivs [GroupAdmin] sta allServiceIds
+            runPrivs [GroupAdmin] sta $ autocreateServiceIfMissing godUid sid
+            allSids' <- runPrivs [GroupAdmin] sta allServiceIds
             allSids `shouldBe` allSids'
 
 spec_agentsAndRoles :: SpecWith ActionState
@@ -284,18 +284,18 @@ spec_agentsAndRoles = describe "agentsAndRoles" $ do
         describe "assign" $ do
             it "can be called by admins" $ \sta -> do
                 [(UserA -> targetAgent, _, _)] <- createTestUsers (sta ^. aStDb) 1
-                result <- runPrivsE [RoleAdmin] sta $ assignRole targetAgent RoleAdmin
+                result <- runPrivsE [GroupAdmin] sta $ assignRole targetAgent GroupAdmin
                 result `shouldSatisfy` isRight
 
             it "can NOT be called by any non-admin agents" $ \sta -> do
                 [(UserA -> targetAgent, _, _)] <- createTestUsers (sta ^. aStDb) 1
-                result <- runPrivsE [targetAgent] sta $ assignRole targetAgent RoleAdmin
+                result <- runPrivsE [targetAgent] sta $ assignRole targetAgent GroupAdmin
                 result `shouldSatisfy` isLeft
 
         describe "lookup" $ do
             it "can be called by admins" $ \sta -> do
                 let targetAgent = UserA $ UserId 1
-                result <- runPrivsE [RoleAdmin] sta $ agentRoles targetAgent
+                result <- runPrivsE [GroupAdmin] sta $ agentRoles targetAgent
                 result `shouldSatisfy` isRight
 
             it "can be called by user for her own roles" $ \sta -> do

--- a/thentos-tests/tests/Thentos/FrontendSpec.hs
+++ b/thentos-tests/tests/Thentos/FrontendSpec.hs
@@ -155,8 +155,8 @@ spec_updateSelf = describe "update self" $ do
         -}
 
 
--- manageRoles :: SpecWith ActionState
--- manageRoles = describe "manage roles" $ do ...
+-- manageGroups :: SpecWith ActionState
+-- manageGroups = describe "manage groups" $ do ...
 
 
 spec_logIntoThentos :: SpecWith ActionState

--- a/thentos-tests/tests/Thentos/TransactionSpec.hs
+++ b/thentos-tests/tests/Thentos/TransactionSpec.hs
@@ -283,41 +283,41 @@ assignRoleSpec :: SpecWith (Pool Connection)
 assignRoleSpec = describe "assignRole" $ do
     it "adds a role" $ \connPool -> do
         [(uid, _, _)] <- createTestUsers connPool 1
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) RoleAdmin
+        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupAdmin
         Right roles <- runVoidedQuery connPool $ agentRoles (UserA uid)
-        roles `shouldBe` [RoleAdmin]
+        roles `shouldBe` [GroupAdmin]
 
         addTestService connPool uid
-        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) RoleAdmin
+        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupAdmin
         Right serviceRoles <- runVoidedQuery connPool $ agentRoles (ServiceA sid)
-        serviceRoles `shouldBe` [RoleAdmin]
+        serviceRoles `shouldBe` [GroupAdmin]
 
     it "silently allows adding a duplicate role" $ \connPool -> do
         [(uid, _, _)] <- createTestUsers connPool 1
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) RoleAdmin
-        x <- runVoidedQuery connPool $ assignRole (UserA uid) RoleAdmin
+        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupAdmin
+        x <- runVoidedQuery connPool $ assignRole (UserA uid) GroupAdmin
         x `shouldBe` Right ()
         Right roles <- runVoidedQuery connPool $ agentRoles (UserA uid)
-        roles `shouldBe` [RoleAdmin]
+        roles `shouldBe` [GroupAdmin]
 
         addTestService connPool uid
-        Right () <- runVoidedQuery connPool $ assignRole (ServiceA sid) RoleAdmin
-        Right () <- runVoidedQuery connPool $ assignRole (ServiceA sid) RoleAdmin
+        Right () <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupAdmin
+        Right () <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupAdmin
         Right serviceRoles <- runVoidedQuery connPool $ agentRoles (ServiceA sid)
-        serviceRoles `shouldBe` [RoleAdmin]
+        serviceRoles `shouldBe` [GroupAdmin]
 
     it "adds a second role" $ \connPool -> do
         [(uid, _, _)] <- createTestUsers connPool 1
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) RoleAdmin
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) RoleUser
+        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupAdmin
+        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupUser
         Right roles <- runVoidedQuery connPool $ agentRoles (UserA uid)
-        Set.fromList roles `shouldBe` Set.fromList [RoleAdmin, RoleUser]
+        Set.fromList roles `shouldBe` Set.fromList [GroupAdmin, GroupUser]
 
         addTestService connPool uid
-        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) RoleAdmin
-        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) RoleUser
+        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupAdmin
+        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupUser
         Right serviceRoles <- runVoidedQuery connPool $ agentRoles (ServiceA sid)
-        Set.fromList serviceRoles `shouldBe` Set.fromList [RoleAdmin, RoleUser]
+        Set.fromList serviceRoles `shouldBe` Set.fromList [GroupAdmin, GroupUser]
 
   where
     sid = "sid"
@@ -328,27 +328,27 @@ unassignRoleSpec :: SpecWith (Pool Connection)
 unassignRoleSpec = describe "unassignRole" $ do
     it "silently allows removing a non-assigned role" $ \connPool -> do
         [(uid, _, _)] <- createTestUsers connPool 1
-        x <- runVoidedQuery connPool $ unassignRole (UserA uid) RoleAdmin
+        x <- runVoidedQuery connPool $ unassignRole (UserA uid) GroupAdmin
         x `shouldBe` Right ()
 
         addTestService connPool uid
-        res <- runVoidedQuery connPool $ unassignRole (ServiceA sid) RoleAdmin
+        res <- runVoidedQuery connPool $ unassignRole (ServiceA sid) GroupAdmin
         res `shouldBe` Right ()
 
     it "removes the specified role" $ \connPool -> do
         [(uid, _, _)] <- createTestUsers connPool 1
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) RoleAdmin
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) RoleUser
-        Right _ <- runVoidedQuery connPool $ unassignRole (UserA uid) RoleAdmin
+        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupAdmin
+        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupUser
+        Right _ <- runVoidedQuery connPool $ unassignRole (UserA uid) GroupAdmin
         Right roles <- runVoidedQuery connPool $ agentRoles (UserA uid)
-        roles `shouldBe` [RoleUser]
+        roles `shouldBe` [GroupUser]
 
         addTestService connPool uid
-        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) RoleAdmin
-        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) RoleUser
-        Right _ <- runVoidedQuery connPool $ unassignRole (ServiceA sid) RoleAdmin
+        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupAdmin
+        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupUser
+        Right _ <- runVoidedQuery connPool $ unassignRole (ServiceA sid) GroupAdmin
         Right serviceRoles <- runVoidedQuery connPool $ agentRoles (ServiceA sid)
-        serviceRoles `shouldBe` [RoleUser]
+        serviceRoles `shouldBe` [GroupUser]
 
   where
     sid = "sid"

--- a/thentos-tests/tests/Thentos/TransactionSpec.hs
+++ b/thentos-tests/tests/Thentos/TransactionSpec.hs
@@ -40,9 +40,9 @@ spec = describe "Thentos.Transaction" . before (thentosTestConfig >>= createDb)
     deleteUserSpec
     passwordResetTokenSpec
     changePasswordSpec
-    agentRolesSpec
-    assignRoleSpec
-    unassignRoleSpec
+    agentGroupsSpec
+    assignGroupSpec
+    unassignGroupSpec
     addPersonaSpec
     deletePersonaSpec
     addContextSpec
@@ -263,92 +263,92 @@ changePasswordSpec = describe "changePassword" $ do
         err `shouldBe` NoSuchUser
 
 
-agentRolesSpec :: SpecWith (Pool Connection)
-agentRolesSpec = describe "agentRoles" $ do
-    it "returns an empty set for a user or service without roles" $
+agentGroupsSpec :: SpecWith (Pool Connection)
+agentGroupsSpec = describe "agentGroups" $ do
+    it "returns an empty set for a user or service without groups" $
       \connPool -> do
         [(userId, _, _)] <- createTestUsers connPool 1
-        x <- runVoidedQuery connPool $ agentRoles (UserA userId)
+        x <- runVoidedQuery connPool $ agentGroups (UserA userId)
         x `shouldBe` Right []
 
         Right _ <- runVoidedQuery connPool $
             addService userId sid testHashedServiceKey "name" "desc"
-        roles <- runVoidedQuery connPool $ agentRoles (ServiceA sid)
-        roles `shouldBe` Right []
+        groups <- runVoidedQuery connPool $ agentGroups (ServiceA sid)
+        groups `shouldBe` Right []
 
   where
     sid = "sid"
 
-assignRoleSpec :: SpecWith (Pool Connection)
-assignRoleSpec = describe "assignRole" $ do
-    it "adds a role" $ \connPool -> do
+assignGroupSpec :: SpecWith (Pool Connection)
+assignGroupSpec = describe "assignGroup" $ do
+    it "adds a group" $ \connPool -> do
         [(uid, _, _)] <- createTestUsers connPool 1
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupAdmin
-        Right roles <- runVoidedQuery connPool $ agentRoles (UserA uid)
-        roles `shouldBe` [GroupAdmin]
+        Right _ <- runVoidedQuery connPool $ assignGroup (UserA uid) GroupAdmin
+        Right groups <- runVoidedQuery connPool $ agentGroups (UserA uid)
+        groups `shouldBe` [GroupAdmin]
 
         addTestService connPool uid
-        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupAdmin
-        Right serviceRoles <- runVoidedQuery connPool $ agentRoles (ServiceA sid)
-        serviceRoles `shouldBe` [GroupAdmin]
+        Right _ <- runVoidedQuery connPool $ assignGroup (ServiceA sid) GroupAdmin
+        Right serviceGroups <- runVoidedQuery connPool $ agentGroups (ServiceA sid)
+        serviceGroups `shouldBe` [GroupAdmin]
 
-    it "silently allows adding a duplicate role" $ \connPool -> do
+    it "silently allows adding a duplicate group" $ \connPool -> do
         [(uid, _, _)] <- createTestUsers connPool 1
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupAdmin
-        x <- runVoidedQuery connPool $ assignRole (UserA uid) GroupAdmin
+        Right _ <- runVoidedQuery connPool $ assignGroup (UserA uid) GroupAdmin
+        x <- runVoidedQuery connPool $ assignGroup (UserA uid) GroupAdmin
         x `shouldBe` Right ()
-        Right roles <- runVoidedQuery connPool $ agentRoles (UserA uid)
-        roles `shouldBe` [GroupAdmin]
+        Right groups <- runVoidedQuery connPool $ agentGroups (UserA uid)
+        groups `shouldBe` [GroupAdmin]
 
         addTestService connPool uid
-        Right () <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupAdmin
-        Right () <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupAdmin
-        Right serviceRoles <- runVoidedQuery connPool $ agentRoles (ServiceA sid)
-        serviceRoles `shouldBe` [GroupAdmin]
+        Right () <- runVoidedQuery connPool $ assignGroup (ServiceA sid) GroupAdmin
+        Right () <- runVoidedQuery connPool $ assignGroup (ServiceA sid) GroupAdmin
+        Right serviceGroups <- runVoidedQuery connPool $ agentGroups (ServiceA sid)
+        serviceGroups `shouldBe` [GroupAdmin]
 
-    it "adds a second role" $ \connPool -> do
+    it "adds a second group" $ \connPool -> do
         [(uid, _, _)] <- createTestUsers connPool 1
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupAdmin
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupUser
-        Right roles <- runVoidedQuery connPool $ agentRoles (UserA uid)
-        Set.fromList roles `shouldBe` Set.fromList [GroupAdmin, GroupUser]
+        Right _ <- runVoidedQuery connPool $ assignGroup (UserA uid) GroupAdmin
+        Right _ <- runVoidedQuery connPool $ assignGroup (UserA uid) GroupUser
+        Right groups <- runVoidedQuery connPool $ agentGroups (UserA uid)
+        Set.fromList groups `shouldBe` Set.fromList [GroupAdmin, GroupUser]
 
         addTestService connPool uid
-        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupAdmin
-        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupUser
-        Right serviceRoles <- runVoidedQuery connPool $ agentRoles (ServiceA sid)
-        Set.fromList serviceRoles `shouldBe` Set.fromList [GroupAdmin, GroupUser]
+        Right _ <- runVoidedQuery connPool $ assignGroup (ServiceA sid) GroupAdmin
+        Right _ <- runVoidedQuery connPool $ assignGroup (ServiceA sid) GroupUser
+        Right serviceGroups <- runVoidedQuery connPool $ agentGroups (ServiceA sid)
+        Set.fromList serviceGroups `shouldBe` Set.fromList [GroupAdmin, GroupUser]
 
   where
     sid = "sid"
     addTestService connPool uid = void . runVoidedQuery connPool $
         addService uid sid testHashedServiceKey "name" "desc"
 
-unassignRoleSpec :: SpecWith (Pool Connection)
-unassignRoleSpec = describe "unassignRole" $ do
-    it "silently allows removing a non-assigned role" $ \connPool -> do
+unassignGroupSpec :: SpecWith (Pool Connection)
+unassignGroupSpec = describe "unassignGroup" $ do
+    it "silently allows removing a non-assigned group" $ \connPool -> do
         [(uid, _, _)] <- createTestUsers connPool 1
-        x <- runVoidedQuery connPool $ unassignRole (UserA uid) GroupAdmin
+        x <- runVoidedQuery connPool $ unassignGroup (UserA uid) GroupAdmin
         x `shouldBe` Right ()
 
         addTestService connPool uid
-        res <- runVoidedQuery connPool $ unassignRole (ServiceA sid) GroupAdmin
+        res <- runVoidedQuery connPool $ unassignGroup (ServiceA sid) GroupAdmin
         res `shouldBe` Right ()
 
-    it "removes the specified role" $ \connPool -> do
+    it "removes the specified group" $ \connPool -> do
         [(uid, _, _)] <- createTestUsers connPool 1
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupAdmin
-        Right _ <- runVoidedQuery connPool $ assignRole (UserA uid) GroupUser
-        Right _ <- runVoidedQuery connPool $ unassignRole (UserA uid) GroupAdmin
-        Right roles <- runVoidedQuery connPool $ agentRoles (UserA uid)
-        roles `shouldBe` [GroupUser]
+        Right _ <- runVoidedQuery connPool $ assignGroup (UserA uid) GroupAdmin
+        Right _ <- runVoidedQuery connPool $ assignGroup (UserA uid) GroupUser
+        Right _ <- runVoidedQuery connPool $ unassignGroup (UserA uid) GroupAdmin
+        Right groups <- runVoidedQuery connPool $ agentGroups (UserA uid)
+        groups `shouldBe` [GroupUser]
 
         addTestService connPool uid
-        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupAdmin
-        Right _ <- runVoidedQuery connPool $ assignRole (ServiceA sid) GroupUser
-        Right _ <- runVoidedQuery connPool $ unassignRole (ServiceA sid) GroupAdmin
-        Right serviceRoles <- runVoidedQuery connPool $ agentRoles (ServiceA sid)
-        serviceRoles `shouldBe` [GroupUser]
+        Right _ <- runVoidedQuery connPool $ assignGroup (ServiceA sid) GroupAdmin
+        Right _ <- runVoidedQuery connPool $ assignGroup (ServiceA sid) GroupUser
+        Right _ <- runVoidedQuery connPool $ unassignGroup (ServiceA sid) GroupAdmin
+        Right serviceGroups <- runVoidedQuery connPool $ agentGroups (ServiceA sid)
+        serviceGroups `shouldBe` [GroupUser]
 
   where
     sid = "sid"


### PR DESCRIPTION
`./docs/terminology.md` was not in sync with the code.  These changes fix wrong uses of the word `role`.