### PR TITLE
Add submodules/servant/servant-lucid to cabal sandbox.

### DIFF
--- a/misc/thentos-install.hs
+++ b/misc/thentos-install.hs
@@ -89,6 +89,7 @@ submoduleSources = map ("submodules" </>)
     , "servant/servant-client"
     , "servant/servant-docs"
     , "servant/servant-blaze"
+    , "servant/servant-lucid"
     , "servant/servant-js"
     , "servant/servant-foreign"
     , "pronk"


### PR DESCRIPTION
this is helpful if software depending on thentos-core wants
to depend on servant-lucid and our dev snapshot of servant
at the same time.