### PR TITLE
Allow lists of content-types in FormH, not just one.

### DIFF
--- a/thentos-core/src/Servant/Missing.hs
+++ b/thentos-core/src/Servant/Missing.hs
@@ -25,6 +25,7 @@ module Servant.Missing
   ,redirect) where
 
 import Control.Lens (prism, Prism', (#))
+import Control.Monad ((>=>))
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad.Except.Missing (finally)
 import Control.Monad.Identity (Identity, runIdentity)
@@ -160,8 +161,8 @@ formRedirectH :: forall payload m htm html uri.
   -> (payload -> m uri)              -- ^ processor2
   -> (View html -> uri -> m html)    -- ^ renderer
   -> ServerT (FormH htm html payload) m
-formRedirectH formAction processor1 processor2 renderer =
-    formH (Nat liftIO) formAction processor1 (\p -> processor2 p >>= redirect) renderer
+formRedirectH formAction processor1 processor2 =
+    formH (Nat liftIO) formAction processor1 (processor2 >=> redirect)
 
 
 redirect :: (MonadServantErr err m, ConvertibleStrings uri SBS) => uri -> m a

--- a/thentos-core/src/Servant/Missing.hs
+++ b/thentos-core/src/Servant/Missing.hs
@@ -67,9 +67,9 @@ instance ThrowError500 ServantErr where
                      (\err -> if errHTTPCode err == 500 then Right (cs (errBody err)) else Left err)
 
 
-type FormH htm html payload =
-         Servant.Get '[htm] html
-    :<|> FormReqBody :> Servant.Post '[htm] html
+type FormH (htm :: [*]) html payload =
+         Servant.Get htm html
+    :<|> FormReqBody :> Servant.Post htm html
 
 data FormReqBody
 

--- a/thentos-core/src/Thentos/Frontend/Handlers/Combinators.hs
+++ b/thentos-core/src/Thentos/Frontend/Handlers/Combinators.hs
@@ -34,7 +34,7 @@ type PostH = Post '[HTM] H.Html
 
 -- All Post request should go through FormH (which handles both Get and Post) such that common
 -- verification such as CSRF protection is enabled.
-type FormH a = UnprotectedFormH.FormH HTM H.Html a
+type FormH a = UnprotectedFormH.FormH '[HTM] H.Html a
 
 
 -- * form construction


### PR DESCRIPTION
We need this in liqd/aula to deliver PlainText versions of
form pages for debugging and development.